### PR TITLE
Make section 'Finding .NET Open Source Projects' easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,21 @@ more generally in the [.NET Foundation forums](http://www.dotnetfoundation.org/)
 
 ## Finding .NET Open Source Projects
 
-There are several open source .NET projects from Microsoft on GitHub, including
-[ASP.NET 5](https://github.com/aspnet/home), [EntityFramework](https://github.com/aspnet/EntityFramework) and [.NET Core 5](https://github.com/Microsoft/dotnet-corefx). Each one of these projects maps to one or more [.NET NuGet package](http://blogs.msdn.com/b/dotnet/p/nugetpackages.aspx) that are published on [NuGet.org](http://nuget.org/).
+There are several open source .NET projects from Microsoft on GitHub and
+CodePlex:
 
-There are other .NET projects from Microsoft on CodePlex, such as [.NET Compiler Platform ("Roslyn")](https://roslyn.codeplex.com).
+* [ASP.NET 5](https://github.com/aspnet/home)
+* [EntityFramework](https://github.com/aspnet/EntityFramework)
+* [.NET Core 5](https://github.com/Microsoft/dotnet-corefx)
+* [.NET Compiler Platform ("Roslyn")](https://roslyn.codeplex.com)
 
-They are also many great open source .NET community projects, including the [Mono Project](https://github.com/mono/) and [JSON.NET](http://json.codeplex.com/).
+Each one of these projects maps to one or more [.NET NuGet package](http://blogs.msdn.com/b/dotnet/p/nugetpackages.aspx)
+that are published on [NuGet.org](http://nuget.org/).
+
+They are also many great open source .NET community projects, such as:
+
+* [Mono Project](https://github.com/mono/)
+* [JSON.NET](http://json.codeplex.com/)
 
 ## Understanding the Relationship between .NET Core and Mono
 


### PR DESCRIPTION
Most folks expected a bullet point with project references instead of a blurb of text with inline links.
