### PR TITLE
Added descriptions to OSS projects.

### DIFF
--- a/dotnet-projects.md
+++ b/dotnet-projects.md
@@ -1,36 +1,36 @@
-# .NET Projects
+# .NET Open Source Projects
 
-There are many .NET open source projects. You can always use a search engine to find projects, and that's a good approach. This list is an intended to provide a showcase for projects that want it. It is itendeded to be community maintained. PR a change in and it will be accepted (modulo duplicates). Projects should be sorted alphabetically and GitHub links are preferred.
+There are many .NET Open Source projects. You can always use a search engine to find projects, and that's a good approach. This list is intended to provide a showcase for projects that want it and to be community maintained. PR a change in and it will be accepted (modulo duplicates). Projects should be sorted alphabetically provide a one-line description and GitHub (or source) links are preferred over marketing sites.
 
 * Platforms
- * [.NET Core](https://github.com/dotnet/core)
- * [Castle Project](https://github.com/castleproject)
- * [Mono Project](https://github.com/mono/)
+ * [.NET Core](https://github.com/dotnet/core) - Core .NET Framework
+ * [Castle Project](https://github.com/castleproject) - Umbrella project for ActiveRecord, DynamicProxy, MonoRail, Windsor
+ * [Mono Project](https://github.com/mono/) - Cross-platform implementation of .NET Framework.
  
 * Languages
- * [IronScheme](http://ironscheme.codeplex.com)
+ * [IronScheme](http://ironscheme.codeplex.com) - A R6RS conforming Scheme-like implementation based on the Microsoft DLR.
 
 * Web Platforms
- * [DotNetNuke](https://dotnetnuke.codeplex.com/)
- * [Nancy](http://nancyfx.org)
- * [Orchard](http://www.orchardproject.net/)
- * [Umbraco](http://umbraco.com/)
+ * [DotNetNuke](https://dotnetnuke.codeplex.com/) - Web content management platform (CMS).
+ * [Nancy](http://nancyfx.org) - A lightweight, low-ceremony, framework for building HTTP based services on .NET and Mono. 
+ * [Orchard](http://www.orchardproject.net/) - A community-focused Content Management System built on the ASP.NET MVC platform.
+ * [Umbraco](http://umbraco.com/) - Web content management platform (CMS).
 
 * Libraries
- * [AngleSharp](https://github.com/FlorianRappl/AngleSharp)
- * [AzureNetQ](https://github.com/Roysvork/AzureNetQ)
- * [Cimbalino](http://cimbalino.org/)
- * [DotNetOpenAuth](https://github.com/DotNetOpenAuth)
- * [EasyNetQ](https://github.com/mikehadlow/EasyNetQ)
- * [FluentValidation](https://github.com/JeremySkinner/FluentValidation)
- * [JSON.NET](http://json.net/)
- * [NodaTime](http://nodatime.org/)
- * [RestSharp](http://restsharp.org/)
- * [SharpDX](https://github.com/sharpdx/SharpDX)
- * [Splat](https://github.com/paulcbetts/splat)
- * [WpfToolkit](https://github.com/dotnetprojects/wpftoolkit)
+ * [AngleSharp](https://github.com/FlorianRappl/AngleSharp) - Ultimate angle brackets parser library. It parses HTML5, MathML, SVG and CSS to construct a DOM based on the official W3C specification.
+ * [AzureNetQ](https://github.com/Roysvork/AzureNetQ) - An easy to use .NET API for Azure Service Bus.
+ * [Cimbalino](http://cimbalino.org/) - A set of useful and powerful tools that will help you build your Windows Platform applications.
+ * [DotNetOpenAuth](https://github.com/DotNetOpenAuth) - Library that adds support for your site visitors to login with their OpenIDs by just dropping an ASP.NET control onto your page.
+ * [EasyNetQ](https://github.com/mikehadlow/EasyNetQ) - An easy to use .NET API for RabbitMQ.
+ * [FluentValidation](https://github.com/JeremySkinner/FluentValidation) - A small validation library for .NET that uses a fluent interface and lambda expressions for building validation rules.
+ * [JSON.NET](http://json.net/) - Popular high-performance JSON framework for .NET
+ * [NodaTime](http://nodatime.org/) - A better date and time API for .NET
+ * [RestSharp](http://restsharp.org/) - Simple REST and HTTP API Client for .NET
+ * [SharpDX](https://github.com/sharpdx/SharpDX) - SharpDX is a project delivering the full DirectX API for .NET on all Windows platforms.
+ * [Splat](https://github.com/paulcbetts/splat) - A library to make things cross-platform that should be.
+ * [WpfToolkit](https://github.com/dotnetprojects/wpftoolkit) - Fork of the MS WPF Toolkit
 
-* Mvvm
+* Model-View-ViewModel (MVVM) Frameworks
  * [Caliburn Micro](http://caliburnmicro.com/)
  * [Catel](http://catelproject.com/)
  * [MVVM Cross](https://github.com/MvvmCross/MvvmCross)
@@ -40,45 +40,45 @@ There are many .NET open source projects. You can always use a search engine to 
  * [Simple Mvvm Toolkit](http://simplemvvmtoolkit.codeplex.com/)
 
 * Tools
- * [Fody](https://github.com/Fody/Fody)
- * [GitVersion](https://github.com/ParticularLabs/GitVersion)
- * [Glimpse](http://getglimpse.com)
- * [ILSpy](http://ilspy.net/)
- * [Mini Profiler](http://miniprofiler.com/)
- * [Protobuf-net](https://code.google.com/p/protobuf-net/)
- * [scriptcs](http://scriptcs.net/)
- * [Snoop Wpf](https://github.com/cplotts/snoopwpf)
+ * [Fody](https://github.com/Fody/Fody) - Extensible tool for weaving .NET assemblies.
+ * [GitVersion](https://github.com/ParticularLabs/GitVersion) - Use convention to derive a SemVer product version from a GitFlow based repository.
+ * [Glimpse](http://getglimpse.com) - Providing real time diagnostics & insights to the fingertips of hundreds of thousands of developers daily.
+ * [ILSpy](http://ilspy.net/) - ILSpy is the open-source .NET assembly browser and decompiler.
+ * [Mini Profiler](http://miniprofiler.com/) - A simple but effective mini-profiler for .NET and Ruby.
+ * [Protobuf-net](https://code.google.com/p/protobuf-net/) - A .NET implementation of protobuf, allowing you to serialize your .NET objects efficiently and easily.
+ * [scriptcs](http://scriptcs.net/) - scriptcs makes it easy to write and execute C# with a simple text editor.
+ * [Snoop WPF](https://github.com/cplotts/snoopwpf) - Snoop - The WPF Spy Utility
 
 * Testing
- * [moq](https://github.com/Moq/moq4)
- * [NSubstitute](http://nsubstitute.github.io/)
- * [NUnit](https://github.com/nunit/nunit)
- * [xUnit](https://github.com/xunit/xunit)
+ * [moq](https://github.com/Moq/moq4) - The most popular and friendly mocking framework for .NET
+ * [NSubstitute](http://nsubstitute.github.io/) - A friendly substitute for .NET mocking frameworks.
+ * [NUnit](https://github.com/nunit/nunit) - NUnit is a unit-testing framework for all .NET languages.
+ * [xUnit](https://github.com/xunit/xunit) - xUnit.net is a community-focused unit testing tool for the .NET Framework.
 
 * Dependency Injection
- * [Autofac](http://autofac.org/)
- * [Funq](https://funq.codeplex.com/)
- * [Ninject for Desktop](http://www.ninject.org/)
- * [Ninject for Portable Class Libraries, Universal apps and Xamarin](https://github.com/onovotny/ninject)
- * [TinyIoC](https://github.com/grumpydev/TinyIoC)
+ * [Autofac](http://autofac.org/) - Autofac is an addictive Inversion of Control container for .NET 4.5, Silverlight 5, Windows Store apps, and Windows Phone 8 apps.
+ * [Funq](https://funq.codeplex.com/) - A fast DI container you can understand.
+ * [Ninject for Desktop](http://www.ninject.org/) - Dependency injector for .NET
+	 * [Ninject for Portable Class Libraries, Universal apps and Xamarin](https://github.com/onovotny/ninject)
+ * [TinyIoC](https://github.com/grumpydev/TinyIoC) - An easy to use, hassle free, Inversion of Control Container for small projects, libraries and beginners alike.
 
 * Data Access
- * [Dapper](https://github.com/StackExchange/dapper-dot-net)
- * [NHibernate](https://github.com/nhibernate)
- * [Simple Data](https://github.com/markrendle/Simple.Data)
- * [Sqlite-net](https://github.com/praeclarum/sqlite-net)
- * [NMEA Parser](https://github.com/dotMorten/NmeaParser)
+ * [Dapper](https://github.com/StackExchange/dapper-dot-net) - Dapper is a single file you can drop in to your project that will extend your IDbConnection interface.
+ * [NHibernate](https://github.com/nhibernate) - Object Relational Mapper
+ * [Simple Data](https://github.com/markrendle/Simple.Data) - A light-weight, dynamic data access component for C# 4.0.
+ * [Sqlite-net](https://github.com/praeclarum/sqlite-net) - Simple, powerful, cross-platform SQLite client and ORM.
+ * [NMEA Parser](https://github.com/dotMorten/NmeaParser) - Library for handling NMEA message in Windows Desktop, Store, Phone and Xamarin (Android + iOS), coming from files, Bluetooth, serial port or any stream.
 
 * Games
- * [MonoGame](http://monogame.net)
- * [Paradox](https://github.com/SiliconStudio/paradox)
+ * [MonoGame](http://monogame.net) - One framework for creating powerful cross-platform games.
+ * [Paradox](https://github.com/SiliconStudio/paradox) - Paradox is a versatile and engaging game engine.
 
 * Control libraries
- * [Callisto](https://github.com/timheuer/callisto)
- * [OpenRA](https://github.com/OpenRA/OpenRA)
+ * [Callisto](https://github.com/timheuer/callisto) - UI Control Toolkit for WinRT apps
+ * [OpenRA](https://github.com/OpenRA/OpenRA) - An open-source implementation of the Command & Conquer: Red Alert engine using .NET/Mono and OpenGL.
  
 This list is just a starting point - also take a look at all the projects on [CodePlex](http://www.codeplex.com/) and on [GitHub Trending C#](https://github.com/trending?l=csharp).
 
-Thanks to @slodge for providing the initial list.
+Thanks to [@slodge](http://twitter.com/slodge "@slodge on Twitter") for providing the initial list.
 
-@quozd hosts an [Awesome .NET!](https://github.com/quozd/awesome-dotnet) list. Also worth checking out.
+[@quozd](http://twitter.com/quozd "@quozd on Twitter") hosts an [Awesome .NET!](https://github.com/quozd/awesome-dotnet) list. Also worth checking out.


### PR DESCRIPTION
This list is awesome, but we are clever with names too much that I don't know what some of them do.  Added one-line descriptions to list when I forked, fixed some typos and changed guidance to add one-line description when modifying.
