### PR TITLE
Update dotnet-projects.md

### DIFF
--- a/dotnet-projects.md
+++ b/dotnet-projects.md
@@ -11,7 +11,7 @@ There are many .NET open source projects. You can always use a search engine to 
  * [IronScheme](http://ironscheme.codeplex.com)
 
 * Web Platforms
- * [DotNetNuke](https://dotnetnuke.codeplex.com/)
+ * [DNN (formerly DotNetNuke)](https://dotnetnuke.codeplex.com/)
  * [Nancy](http://nancyfx.org)
  * [Orchard](http://www.orchardproject.net/)
  * [Umbraco](http://umbraco.com/)


### PR DESCRIPTION
DotNetNuke was rebranded in July 2013 to DNN.
