### PR TITLE
Please, add LINQ2DynamoDB to data access section

### DIFF
--- a/dotnet-developer-projects.md
+++ b/dotnet-developer-projects.md
@@ -156,6 +156,7 @@ There are many .NET open source developer projects. You can always use a search 
  * [NMEA Parser](https://github.com/dotMorten/NmeaParser) - Library for handling NMEA message in Windows Desktop, Store, Phone and Xamarin (Android + iOS), coming from files, Bluetooth, serial port or any stream.
  * [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis)  
  * [SQL LocalDB Wrapper](https://github.com/martincostello/sqllocaldb) - SQL LocalDB Wrapper is an assembly providing interop with the SQL LocalDB native API from managed code using .NET APIs.
+ * [LINQ2DynamoDB](http://linq2dynamodb.codeplex.com) - A type-safe data context for AWS DynamoDB with LINQ, in-memory caching and OData support.   
 
 
 * Games


### PR DESCRIPTION
LINQ2DynamoDb is a type-safe data context for AWS DynamoDB with LINQ and in-memory caching support. 

Allows to combine DynamoDB's durability with cache speed and read consistency. Translates LINQ queries into corresponding DynamoDB Get/Query/Scan operations and stores query results in an in-memory cache. Data updates are propagated both to DynamoDB and cache.

Bridges the gap between AWS SDK's object model and Microsoft's stack of data access technologies like data binding, ASP.Net datasources etc. Also allows to easily expose data from DynamoDB as an OData endpoint.
