### PR TITLE
General cleanup

### DIFF
--- a/dotnet-developer-projects.md
+++ b/dotnet-developer-projects.md
@@ -19,40 +19,40 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
 * Languages
  * [ClojureCLR](https://github.com/clojure/clojure-clr) - A .NET implemention of the [Clojure](http://clojure.org) programming language, built on the DLR. 
  * [Dynamic Language Runtime](http://www.github.com/IronLanguages/main.git) - A toolkit for building dynamic languages for .NET.
+ * [Eagle](http://eagle.to) - A .NET implementation of the [Tcl](https://www.tcl.tk) programming language, built on the CLR.
  * [IronPython](http://ironpython.net) - A .NET implementation of the [Python](https://www.python.org) programming language, built on the DLR.
  * [IronRuby](http://ironruby.net) - A .NET implementation of the [Ruby](https://www.ruby-lang.org) programming language, built on the DLR.
  * [IronScheme](http://ironscheme.codeplex.com) - A R6RS conforming Scheme-like implementation based on the Microsoft DLR.
- * [Nemerle](https://github.com/rsdn/nemerle) A high-level statically-typed programming language which offers functional, object-oriented and imperative features and has a simple C# like syntax and a powerful meta-programming system.
- * [Eagle](http://eagle.to) A .NET implementation of the [Tcl](https://www.tcl.tk) programming language, built on the CLR.
- * [MoonSharp](http://www.moonsharp.org) A Lua interpreter and remote debugger, written entirely in C#, easily embeddable in any application running on .NET 3.5+ and Mono.
- * [NiL.JS](https://github.com/nilproject/NiL.JS) A .NET implementation of the ECMAScript language and runtime.
+ * [MoonSharp](http://www.moonsharp.org) - A Lua interpreter and remote debugger, written entirely in C#, easily embeddable in any application running on .NET 3.5+ and Mono.
+ * [Nemerle](https://github.com/rsdn/nemerle) - A high-level statically-typed programming language which offers functional, object-oriented and imperative features and has a simple C# like syntax and a powerful meta-programming system.
+ * [NiL.JS](https://github.com/nilproject/NiL.JS) - A .NET implementation of the ECMAScript language and runtime.
 
 * Security / Identity Management
- * [Thinktecture IdentityServer](https://github.com/thinktecture/Thinktecture.IdentityServer.v3)
  * [Thinktecture IdentityManager](https://github.com/thinktecture/Thinktecture.IdentityManager)
- * [SKGL - Serial Key Generating Library] (https://skgl.codeplex.com/)
+ * [Thinktecture IdentityServer](https://github.com/thinktecture/Thinktecture.IdentityServer.v3)
+ * [SKGL - Serial Key Generating Library](https://skgl.codeplex.com/)
 
 * Web CMS
  * [DNN (formerly DotNetNuke)](https://dotnetnuke.codeplex.com/) - Web content management platform (CMS).
+ * [N2CMS](http://www.n2cms.com/) - Open source, lightweight, code-first CMS able to seamlessly integrate into any MVC project.
  * [Orchard](http://www.orchardproject.net/) - A community-focused Content Management System built on the ASP.NET MVC platform.
  * [Piranha CMS](http://piranhacms.org) - Lightweight CMS library for new and existing ASP.NET MVC & WebPages applications.
  * [Suave](https://github.com/SuaveIO/suave) A lightweight web server and a set of combinators to manipulate route flow and task composition.
  * [Umbraco](http://umbraco.com/) - Web content management platform (CMS).
- * [WebSharper](https://bitbucket.org/IntelliFactory/websharper)  Web programming platform including a compiler from F# code to JavaScript.
- * [N2CMS](http://www.n2cms.com/) - Open source, lightweight, code-first CMS able to seamlessly integrate into any MVC project.
+ * [WebSharper](https://bitbucket.org/IntelliFactory/websharper) - Web programming platform including a compiler from F# code to JavaScript.
 
 * Web Frameworks
  * [Nancy](http://nancyfx.org) - A lightweight, low-ceremony, framework for building HTTP based services on .NET and Mono. 
  * [NemerleWeb](https://github.com/NemerleWeb/NemerleWeb) - Web MVVM library for .Net. It uses reactive data model which allows creating rich internet applications.
 
 * ADO.NET providers
- * [Npgsql](https://github.com/npgsql/npgsql) PostgreSQL 
- * [Firebird .NET client](https://sourceforge.net/p/firebird/NETProvider/) Firebird
- * [System.Data.SQLite](https://system.data.sqlite.org) SQLite
+ * [Firebird .NET client](https://sourceforge.net/p/firebird/NETProvider/) - Firebird
+ * [Npgsql](https://github.com/npgsql/npgsql) - PostgreSQL 
+ * [System.Data.SQLite](https://system.data.sqlite.org) - SQLite
  
 * Libraries
  * [Albedo](https://github.com/ploeh/Albedo) - A .NET library targeted at making Reflection programming more consistent, using a common set of abstractions and utilities.
- * [Algorithmia](https://github.com/SolutionsDesign/Algorithmia) Algorithms and Data structures
+ * [Algorithmia](https://github.com/SolutionsDesign/Algorithmia) - Algorithms and Data structures
  * [AngleSharp](https://github.com/FlorianRappl/AngleSharp) - Ultimate angle brackets parser library. It parses HTML5, MathML, SVG and CSS to construct a DOM based on the official W3C specification.
  * [ArcGIS.PCL](https://github.com/davetimmins/ArcGIS.PCL) - Call ArcGIS Server REST API resources. You can also convert between ArcGIS features and GeoJSON.
  * [Argument](https://github.com/ashmind/Argument) - Argument validation microframework that does one thing in the simplest way possible.
@@ -60,12 +60,12 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  * [AsyncCollections](https://github.com/HellBrick/AsyncCollections) - A set of lock-free thread-safe collections designed to be used asynchronously.
  * [AzureNetQ](https://github.com/Roysvork/AzureNetQ) - An easy to use .NET API for Azure Service Bus.
  * [Bing.RestClient](https://github.com/AdvancedREI/Bing.RestClient) - Access the Bing REST APIs from a unified client.
- * [BoxKite.Twitter]() - Twitter .NET Client Library for the 1.1 Twitter API, incorporating REST API, User streaming and Search Streaming. Uses Reactive Extensions (Rx) .Subscribe to Tweets!
+ * [BoxKite.Twitter](https://github.com/NickHodge/BoxKite.Twitter/) - Twitter .NET Client Library for the 1.1 Twitter API, incorporating REST API, User streaming and Search Streaming. Uses Reactive Extensions (Rx).
  * [Cimbalino Toolkit](http://cimbalino.org/) - A set of useful and powerful tools that will help you build your Windows Platform applications.
  * [Coding4Fun Toolkit](http://coding4fun.codeplex.com/)
  * [ColoredConsole](https://github.com/colored-console/colored-console) - Add some color to your console.
  * [Cricket](http://fsprojects.github.io/Cricket/) - Actor library
- * [DiffSharp](http://gbaydin.github.io/DiffSharp/) Automatic Differentiation Library
+ * [DiffSharp](http://gbaydin.github.io/DiffSharp/) - Automatic Differentiation Library
  * [DotNetOpenAuth](https://github.com/DotNetOpenAuth) - Library that adds support for your site visitors to login with their OpenIDs by just dropping an ASP.NET control onto your page.
  * [DynamicData](https://github.com/RolandPheasant/DynamicData) - Brings the power of Rx to collections
  * [EasyNetQ](https://github.com/mikehadlow/EasyNetQ) - An easy to use .NET API for RabbitMQ.
@@ -74,26 +74,26 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  * [FluentBootstrap](https://github.com/somedave/FluentBootstrap)
  * [FluentConsole](https://github.com/ashmind/FluentConsole) - Alternative approach to colored console (`FluentConsole.Red.Text().Green.Text()`).
  * [FluentValidation](https://github.com/JeremySkinner/FluentValidation) - A small validation library for .NET that uses a fluent interface and lambda expressions for building validation rules.
- * [GongSolutions.Wpf.DragDrop](https://github.com/punker76/gong-wpf-dragdrop) A drag'n'drop framework for WPF.
+ * [GongSolutions.Wpf.DragDrop](https://github.com/punker76/gong-wpf-dragdrop) - A drag'n'drop framework for WPF.
  * [HudlFfmpeg](https://github.com/hudl/HudlFfmpeg) - A/V transcoding framework that helps build complex FFmpeg commands.
- * [Kentor.AuthServices](https://github.com/KentorIT/authservices) A SAML2 Service Provider for .NET.
+ * [JSON.NET](http://json.net/) - Popular high-performance JSON framework for .NET
+ * [Kentor.AuthServices](https://github.com/KentorIT/authservices) - A SAML2 Service Provider for .NET.
  * [LibGit2Sharp](https://github.com/libgit2/libgit2sharp)
  * [Lucene.Net](https://github.com/apache/lucene.net)
  * [MahApps.Metro](https://github.com/MahApps/MahApps.Metro) - A toolkit for creating metro-style WPF applications.
- * [Math.NET Numerics](http://numerics.mathdotnet.com/) Provides methods and algorithms for numerical computations in science, engineering and every day use.
+ * [Math.NET Numerics](http://numerics.mathdotnet.com/) - Provides methods and algorithms for numerical computations in science, engineering and every day use.
  * [Mathos Core Libary](http://mathos.codeplex.com/) - A library with algorithms for numerical calcultations in finance, statistics, pattern recognition, and more.
  * [Mathos Parser](http://mathosparser.codeplex.com/) - A simple parser for mathematical expressions before and at runtime.
  * [Mjolnir](https://github.com/hudl/Mjolnir) - [Hystrix](https://github.com/Netflix/Hystrix)-inspired fault tolerance with circuit breakers and thread pools.
  * [MoreLINQ](https://code.google.com/p/morelinq/) - LINQ to Objects is missing a few desirable features. This project will enhance LINQ to Objects with extra methods, in a manner which keeps to the spirit of LINQ.
- * [NetTopologySuite](https://github.com/NetTopologySuite) A .NET port of the JTS Topology Suite.
- * [JSON.NET](http://json.net/) - Popular high-performance JSON framework for .NET
+ * [NetTopologySuite](https://github.com/NetTopologySuite) - A .NET port of the JTS Topology Suite.
  * [NodaTime](http://nodatime.org/) - A better date and time API for .NET
- * [OsmSharp](https://github.com/OsmSharp) Mapping & Routing library.
+ * [OsmSharp](https://github.com/OsmSharp) - Mapping & Routing library.
  * [PocketSharp](https://github.com/ceee/PocketSharp)
- * [PortableRest](https://github.com/AdvancedREI/PortableRest) Portable library for building cross-platform REST API Clients for .NET and Xamarin.
+ * [PortableRest](https://github.com/AdvancedREI/PortableRest) - Portable library for building cross-platform REST API Clients for .NET and Xamarin.
  * [RestSharp](http://restsharp.org/) - Simple REST and HTTP API Client for .NET
  * [RestBus](http://restbus.org/) - Easy Asynchronous Messaging and Queueing for .NET
- * [SharpMap](https://sharpmap.codeplex.com/) An easy-to-use mapping library for use in web and desktop applications
+ * [SharpMap](https://sharpmap.codeplex.com/) - An easy-to-use mapping library for use in web and desktop applications
  * [SharpSnmpLib](https://sharpsnmplib.codeplex.com) - An easy-to-use SNMP library for use on all platforms (.NET/Mono/Xamarin)
  * [Splat](https://github.com/paulcbetts/splat) - A library to make things cross-platform that should be.
  * [SSH.NET](https://sshnet.codeplex.com/) - A client-side library for SSH, SCP and SFTP.
@@ -105,12 +105,12 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  * [Zlib.Portable](https://github.com/AdvancedREI/Zlib.Portable) - A Portable Class Library port of the Zlib library from http://dotnetzip.codeplex.com.
 
 * Graphics & Server-side Image Processing
- * [.NET Image Processor](http://dotnetimageprocessor.codeplex.com/) - Extensible, chainable image processing library (GDI+ based) (Ms-PL).
- * [ImageResizer](http://imageresizing.net/) - Add commands to image URLs to get altered versions in milliseconds. Edit, filter, touch-up images in real-time. (multiple backends - FreeImage, C++/CLI, GDI+, WIC). 45+ plugins available. ([Apache 2 / AGPL](https://github.com/imazen/resizer/blob/develop/LICENSE.md))
- * [DynamicImage](https://github.com/tgjones/dynamic-image) - WPF-based server-side image rendering system - lots of visual effects implemented as high-performance shaders. Has URL api, several plugins available. (Apache 2)
- * [ImageProcessor](http://imageprocessor.org/) - A .NET Library For On-The-Fly Processing Of Images (GDI+ based) (Apache 2).
- * [SharpDX](https://github.com/sharpdx/SharpDX) - SharpDX is a project delivering the full DirectX API for .NET on all Windows platforms.
+ * [DynamicImage](https://github.com/tgjones/dynamic-image) - WPF-based server-side image rendering system - lots of visual effects implemented as high-performance shaders. Has URL api, several plugins available.
+ * [ImageProcessor](http://imageprocessor.org/) - A .NET Library For On-The-Fly Processing Of Images (GDI+ based).
+ * [ImageResizer](http://imageresizing.net/) - Add commands to image URLs to get altered versions in milliseconds. Edit, filter, touch-up images in real-time. (multiple backends - FreeImage, C++/CLI, GDI+, WIC). 45+ plugins available.
  * [King.Azure.Imaging](https://github.com/jefking/King.Azure.Imaging) - Scalable image uploading and processing for Azure.
+ * [.NET Image Processor](http://dotnetimageprocessor.codeplex.com/) - Extensible, chainable image processing library (GDI+ based).
+ * [SharpDX](https://github.com/sharpdx/SharpDX) - SharpDX is a project delivering the full DirectX API for .NET on all Windows platforms.
 
 * Logging
  * [Exceptionless](https://github.com/exceptionless/Exceptionless) - Provides real-time .NET error reporting for your ASP.NET, Web API, WebForms, WPF, Console, and MVC apps. It organizes the gathered information into simple actionable data that will help your app become exceptionless!
@@ -126,52 +126,54 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  * [Simple Mvvm Toolkit](http://simplemvvmtoolkit.codeplex.com/)
 
 * Tools
- * [Cake](https://github.com/cake-build/cake) (C# Make) is a build automation system with C#/Roslyn driven build scripts.
+ * [Cake](https://github.com/cake-build/cake) (C# Make) - A build automation system with C#/Roslyn driven build scripts.
+ * [CInject](http://codeinject.codeplex.com) - A tool to inject your C#/VB.NET code into existing .NET assemblies and executables
+ * [FAKE](http://fsharp.github.io/FAKE/) - Build automation system with capabilities which are similar to make and rake.
  * [Fody](https://github.com/Fody/Fody) - Extensible tool for weaving .NET assemblies.
- * [FAKE](http://fsharp.github.io/FAKE/) Build automation system with capabilities which are similar to make and rake.
- * [FsEye](http://www.swensensoftware.com/fseye) A visual object tree inspector for the F# Interactive.
- * [FsPickler](http://nessos.github.io/FsPickler/) Serialization library that facilitates the distribution of .NET objects.
- * [FsharpLint](http://fsprojects.github.io/FSharpLint/) Lint tool for F#.
+ * [FsEye](http://www.swensensoftware.com/fseye) - A visual object tree inspector for the F# Interactive.
+ * [FsharpLint](http://fsprojects.github.io/FSharpLint/) - Lint tool for F#.
+ * [FsPickler](http://nessos.github.io/FsPickler/) - Serialization library that facilitates the distribution of .NET objects.
  * [GitLink](https://github.com/CatenaLogic/GitLink) - Command-line tool to make .NET open source accessible without the need for a symbols server
  * [GitVersion](https://github.com/ParticularLabs/GitVersion) - Use convention to derive a SemVer product version from a GitFlow based repository.
  * [Glimpse](http://getglimpse.com) - Providing real time diagnostics & insights to the fingertips of hundreds of thousands of developers daily.
  * [ILSpy](http://ilspy.net/) - ILSpy is the open-source .NET assembly browser and decompiler.
  * [Mini Profiler](http://miniprofiler.com/) - A simple but effective mini-profiler for .NET and Ruby.
- * [Paket](http://fsprojects.github.io/Paket/) Dependency manager for .NET and Mono projects, which is designed to work well with NuGet packages and also enables referencing files directly from GitHub repositories.
+ * [Obfuscar](https://obfuscar.codeplex.com) - MSIL obfuscation utility for .NET assemblies.
+ * [Outcomes.Net](https://github.com/kinetiq/Ether.Outcomes/) - Fluent wrapper that eliminates plumbing code around failure-prone functions.
+ * [Paket](http://fsprojects.github.io/Paket/) - Dependency manager for .NET and Mono projects, which is designed to work well with NuGet packages and also enables referencing files directly from GitHub repositories.
  * [Protobuf-net](https://code.google.com/p/protobuf-net/) - A .NET implementation of protobuf, allowing you to serialize your .NET objects efficiently and easily.
  * [scriptcs](http://scriptcs.net/) - scriptcs makes it easy to write and execute C# with a simple text editor.
  * [Snoop WPF](https://github.com/cplotts/snoopwpf) - Snoop - The WPF Spy Utility
  * [Sql Bulk Copy Sync](https://github.com/WCOMAB/SqlBulkSync)
- * [Vagrant](http://nessos.github.io/Vagrant/) Automated dependency resolution and dynamic assembly compilation framework.
- * [Obfuscar](https://obfuscar.codeplex.com) - MSIL obfuscation utility for .NET assemblies.
- * [Outcomes.Net](https://github.com/kinetiq/Ether.Outcomes/) Fluent wrapper that eliminates plumbing code around failure-prone functions.
- * [Weighted Selector](https://github.com/kinetiq/Ether.WeightedSelector/) Easy to use (but high performance!) weighted selection implementation.
+ * [Vagrant](http://nessos.github.io/Vagrant/) - Automated dependency resolution and dynamic assembly compilation framework.
+ * [Weighted Selector](https://github.com/kinetiq/Ether.WeightedSelector/) - Easy to use (but high performance!) weighted selection implementation.
  * [ZeroToNine](https://github.com/ploeh/ZeroToNine) - A tool for maintaining .NET Assembly versions across multiple files.
- * [CInject](http://codeinject.codeplex.com) - A tool to inject your C#/VB.NET code into existing .NET assemblies and executables
 
 * Testing
  * [AutoFixture](https://github.com/AutoFixture/AutoFixture) - An open source framework for .NET designed to minimize the 'Arrange' phase of your unit tests. Its primary goal is to allow developers to focus on what is being tested rather than how to setup the test scenario, by making it easier to create object graphs containing test data.
- * [canopy](http://lefthandedgoat.github.io/canopy/) A web testing framework.
+ * [canopy](http://lefthandedgoat.github.io/canopy/) - A web testing framework.
  * [FakeItEasy](https://github.com/FakeItEasy/FakeItEasy) - The easy mocking library for .NET.
- * [FsCheck](https://fsharp.github.io/FsCheck/) A tool for testing .NET programs automatically.
+ * [FsCheck](https://fsharp.github.io/FsCheck/) - A tool for testing .NET programs automatically.
  * [moq](https://github.com/Moq/moq4) - The most popular and friendly mocking framework for .NET
  * [NSubstitute](http://nsubstitute.github.io/) - A friendly substitute for .NET mocking frameworks.
  * [NUnit](https://github.com/nunit/nunit) - NUnit is a unit-testing framework for all .NET languages.
- * [tickspec](http://tickspec.codeplex.com/) A lightweight Behaviour Driven Development (BDD) framework.
- * [xUnit](https://github.com/xunit/xunit) - xUnit.net is a community-focused unit testing tool for the .NET Framework.
+ * [tickspec](http://tickspec.codeplex.com/) - A lightweight Behaviour Driven Development (BDD) framework.
+ * [TestStack.BDDfy](https://github.com/TestStack/TestStack.BDDfy) - BDDfy is the simplest BDD framework to use, customize and extend!
  * [TestStack.FluentMvcTesting](https://github.com/TestStack/TestStack.FluentMVCTesting) - Simple, terse, fluent unit testing for ASP.NET MVC Controllers.
  * [TestStack.Seleno](https://github.com/TestStack/TestStack.Seleno) - Seleno helps you write automated UI tests in the right way by implementing Page Objects and Page Components and by reading from and writing to web pages using strongly typed view models.
- * [TestStack.BDDfy](https://github.com/TestStack/TestStack.BDDfy) - BDDfy is the simplest BDD framework to use, customize and extend!
  * [TestStack.White](https://github.com/TestStack/White) - White is a framework for automating rich client applications based on Win32, WinForms, WPF, Silverlight and SWT (Java) platforms.
+ * [xUnit](https://github.com/xunit/xunit) - xUnit.net is a community-focused unit testing tool for the .NET Framework.
 
 * Dependency Injection
  * [Autofac](http://autofac.org/) - Autofac is an addictive Inversion of Control container for .NET 4.5, Silverlight 5, Windows Store apps, and Windows Phone 8 apps.
+ * [Castle Windsor](http://www.castleproject.org/projects/windsor/) - A mature Inversion of Control container available for .NET and Silverlight
+ * [DI Feature Tests](http://featuretests.apphb.com/DependencyInjection.html) - Tests that track commmon DI features among multiple containers
+ * [dI.Hook](http://dihook.codeplex.com) - DI container that allows invocation using AOP
  * [DryIoc](https://bitbucket.org/dadhi/dryioc) - DryIoc is small, fast, capable IoC Container for .NET
  * [fFastInjector](https://ffastinjector.codeplex.com/) - fFastInjector is a high-performing dependency injector, service locator, and/or IOC (inversion of control) container.
  * [Funq](https://funq.codeplex.com/) - A fast DI container you can understand.
  * [Grace](https://github.com/ipjohnson/Grace) - Grace is a feature rich Dependency Injection container in a portable class library 
  * [Griffin](https://github.com/jgauffin/griffin.container) - Inversion of control container with (almost) zero configuration
- * [dI.Hook](http://dihook.codeplex.com) - DI container that allows invocation using AOP
  * [HaveBox](https://bitbucket.org/Have/havebox/wiki/Home) - HaveBox is a very fast and lightweight IoC containter. The goal is to keep it fast and light, and at the same time easy to use.
  * [Hiro](https://github.com/philiplaureano/Hiro) - An ultra-lightweight, inversion of control container compiler framework 
  * [IfInjector](https://github.com/iamahern/IfInjector) - High performance mobile micro-IoC container.
@@ -182,18 +184,17 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  * [Ninject for Desktop](http://www.ninject.org/) - Dependency injector for .NET
  * [Ninject for Portable Class Libraries, Universal apps and Xamarin](https://github.com/onovotny/ninject)
  * [QuickInject](https://github.com/isabgol/QuickInject) - QuickInject is a Unity 3.5 based IoC container that aims to give the Unity container a performance advantage in basic scenarios. 
- * [Simple Injector](https://simpleinjector.org/index.html) - Simple Injector is an easy-to-use Dependency Injection (DI) library for .NET 4+ that supports Silverlight 4+, Windows Phone 8, Windows 8 including Universal apps and Mono.
+ * [Simple Injector](https://simpleinjector.org/index.html) - Simple Injector is an easy-to-use Dependency Injection library for .NET 4+ that supports Silverlight 4+, Windows Phone 8, Windows 8 including Universal apps and Mono.
  * [Spring.NET](http://www.springframework.net/) - Spring.NET is an open source application framework that makes building  enterprise .NET applications easier.  
  * [StructureMap](http://docs.structuremap.net/) - StructureMap is a Dependency Injection / Inversion of Control tool for .Net that can be used to improve the architectural qualities of an object oriented system by reducing the mechanical costs of good design techniques.
  * [StyleMVVM](https://stylemvvm.codeplex.com/) - Style MVVM is a toolkit designed for the Windows Store platform around the idea of being light weight and fast.
  * [TinyIoC](https://github.com/grumpydev/TinyIoC) - An easy to use, hassle free, Inversion of Control Container for small projects, libraries and beginners alike.
  * [Unity Container](http://msdn.microsoft.com/library/ff647202.aspx) - The Unity Container (Unity) is a lightweight, extensible dependency injection container with optional support for instance and type interception.
- * [Castle Project/Windsor](http://www.castleproject.org/) - IOC / Proxy
- * [IOC Comparison](http://www.palmmedia.de/blog/2011/8/30/ioc-container-benchmark-performance-comparison) - IoC Container Benchmark - Performance comparison
- * [DI Feature Tests](http://featuretests.apphb.com/DependencyInjection.html) - Tests that track commmon DI features among multiple containers
 
 * Data Access
  * [Dapper](https://github.com/StackExchange/dapper-dot-net) - Dapper is a single file you can drop in to your project that will extend your IDbConnection interface.
+ * [Eggado](https://code.google.com/p/eggado/) - Eggado takes generics, lambdas, expression trees, dynamic methods and DLR and uses them to breathe new life into data access using good old ADO.NET. It's for folks who can live with a SQL dialect.
+ * [King.Mapper](https://github.com/jefking/King.Mapper) - High performance model mapping.
  * [linq2db](https://github.com/linq2db/linq2db/) - Lightweight ORM and LINQ provider with support for various databases including MS SQL, PostgreSQL, Oracle and MySQL
  * [NHibernate](https://github.com/nhibernate) - Object Relational Mapper
  * [Simple Data](https://github.com/markrendle/Simple.Data) - A light-weight, dynamic data access component for C# 4.0.
@@ -203,37 +204,35 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  * [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis)  
  * [SQL LocalDB Wrapper](https://github.com/martincostello/sqllocaldb) - SQL LocalDB Wrapper is an assembly providing interop with the SQL LocalDB native API from managed code using .NET APIs.
  * [LINQ2DynamoDB](http://linq2dynamodb.codeplex.com) - A type-safe data context for AWS DynamoDB with LINQ, in-memory caching and OData support.   
- * [Eggado](https://code.google.com/p/eggado/) - C# and CLR have come a long way since their inception. ADO.NET has been around as long but not evolved nearly as much. Eggado takes generics, lambdas, expression trees, dynamic methods and DLR and uses them to breathe new life into data access using good old ADO.NET. It's for folks who can live with a SQL dialect.
- * [King.Mapper](https://github.com/jefking/King.Mapper) - High performance model mapping.
 
 * Games
- * [MonoGame](http://monogame.net) - One framework for creating powerful cross-platform games.
  * [Duality](https://github.com/AdamsLair/duality) - An Open Source 2D Game Engine + Visual Editor written entirely in C#.
- * [Paradox](https://github.com/SiliconStudio/paradox) - Paradox is a versatile and engaging game engine.
+ * [MonoGame](http://monogame.net) - One framework for creating powerful cross-platform games.
  * [OpenRA](https://github.com/OpenRA/OpenRA) - An open-source implementation of the Command & Conquer: Red Alert engine using .NET/Mono and OpenGL.
+ * [Paradox](https://github.com/SiliconStudio/paradox) - Paradox is a versatile and engaging game engine.
  * [WaveEngine](https://github.com/waveengine) - A powerful component based game engine for desktop and mobile platforms using C#.
  
 * UI and Control libraries
  * [Callisto](https://github.com/timheuer/callisto) - UI Control Toolkit for WinRT apps
+ * [Dragablz](http://github.com/ButchersBoy/Dragablz) - A tearable TabControl for WPF which also provides easy-to-use and implement docking features.
  * [Eto](https://github.com/picoe/Eto) - Cross platform GUI Toolkit for desktop and mobile apps
  * [Mono XWT](https://github.com/mono/xwt) - A cross-platform UI toolkit for creating desktop apps
- * [Dragablz](http://github.com/ButchersBoy/Dragablz) - A tearable TabControl for WPF which also provides easy-to-use and implement docking features.
  
 * Windows Services
- * [TopShelf](https://github.com/Topshelf/Topshelf)
  * [King.Service](https://github.com/jefking/King.Service) - Task scheduling for Azure and Windows
+ * [TopShelf](https://github.com/Topshelf/Topshelf)
 
 * Scheduling
- * [Quartz.Net](https://github.com/quartznet/quartznet) 
  * [Hangfire](http://hangfire.io/)
+ * [Quartz.Net](https://github.com/quartznet/quartznet) 
  
 * Deployment
  * [DropkicK](https://github.com/chucknorris/dropkick/) - A fluent deployment library for Windows applications
  * [RoundHouse](https://code.google.com/p/roundhouse/) - RoundhousE is a Database Migration Utility for .NET using sql files and versioning based on source control
  
 * Service Bus
-  * [Warewolf Easy Service Bus](https://github.com/Warewolf-ESB/Warewolf-ESB) - An open source easy to use service bus, built on numerous .Net technologies including WF (Windows Workflow Foundation), SignalR and WPF.
   * [King.Service.ServiceBus](https://github.com/jefking/King.Service.ServiceBus) - Task scheduling for Azure and Windows Servers: Service Bus.
+  * [Warewolf Easy Service Bus](https://github.com/Warewolf-ESB/Warewolf-ESB) - An open source easy to use service bus, built on numerous .Net technologies including WF (Windows Workflow Foundation), SignalR and WPF.
 
 * Distributed Caching and Computing
   * [Dache](https://github.com/ironyx/dache) - An open source distributed caching service, built on .NET 4.0 and using TCP sockets for communication.


### PR DESCRIPTION
- sorted sections alphabetically
- used the same format (with a hyphen) everywhere
- removed link to an article about IOC Comparison, since that's not a project
- other small fixes (shortened overlong descriptions, added missing URL, more specific URL, removed license from descriptions, …)
