### PR TITLE
Add free services and tools for open source .NET projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ For a longer list, see:
 * [.NET developer projects](dotnet-developer-projects.md)
 * [.NET consumer projects](dotnet-consumer-projects.md) 
 
+For a list of free services and tools for open source .NET projects, see:
+
+* [Free Services & Tools for Open Source .NET Projects](dotnet-free-oss-services.md)
+
 ## How to Engage, Contribute and Provide Feedback
 
 .NET open source projects from Microsoft (gladly) accept PRs and other

--- a/dotnet-free-oss-services.md
+++ b/dotnet-free-oss-services.md
@@ -1,0 +1,41 @@
+# Free Services & Tools for Open Source .NET Projects
+
+This community maintained list showcases free tools and services for open source software development on .NET. If you know of any additions to this list PR a change. This list focuses on services specifically supporting .NET development - a list covering a wide range of platforms is available at [OSS Perks](http://ossperks.com/).
+
+Please sort projects alphabetically and provide a one-line description. Where possible links should be to a page showing free open source plans (for example a web page, blog post or pricing page with open source plan detailed). Create new sections, as appropriate.
+
+* IDEs
+ * [ReSharper](http://www.jetbrains.com/resharper/buy/choose_edition.jsp?license=OPEN_SOURCE) - Visual Studio extension providing code analysis, formatting, refactoring and more.
+ * [Visual Studio Community](http://www.visualstudio.com/en-gb/products/visual-studio-community-vs) - Full version of Visual Studio available free
+ * [VS Anywhere](https://vsanywhere.com/open_source_students_and_educational_centers.aspx) - Visual Studio extension for in IDE collaborative development.
+
+* Cross Platform Development
+ * [Xamarin](http://resources.xamarin.com/open-source-contributor.html) - Share .Net code across Windows, iOS, Android and Mac.
+
+* Hosted Build and Continous Integration
+  * [AppVeyor](http://www.appveyor.com/pricing) - Windows based cloud build/CI servers tailored for .Net developers.
+  * [TeamCity at CodeBetter](http://codebetter.com/codebetter-ci) - JetBrains TeamCity CI server made available for open source projects by CodeBetter.
+  * [TravisCI](https://travis-ci.com/plans) - Hosted CI service supporting .Net builds via Mono on Linux.
+
+* Profilers
+ * [ANTS Memory Profiler](http://reflectorblog.red-gate.com/2013/07/open-source) - .Net memory profiler from redgate.
+ * [ANTS Performance Profiler](http://reflectorblog.red-gate.com/2013/07/open-source) - .Net performance profiler from redgate.
+ * [dotTrace](http://www.jetbrains.com/profiler/buy/choose_edition.jsp?license=OPEN_SOURCE) - Performance profiler for .Net applications
+
+* Aspect Oriented Programming
+ * [PostSharp](http://www.postsharp.net/purchase#discounts) - Aspect-oriented programming tool to eradicate boilerplate code.
+
+* Code Analysis
+ * [Coverity Scan](https://scan.coverity.com) - Static analysis service to identify defects in C# code.
+ * [dotCover](http://www.jetbrains.com/dotcover/buy/choose_edition.jsp?license=OPEN_SOURCE) - Code coverage tool integrated with Visual Studio.
+ * [.Net Reflector](http://reflectorblog.red-gate.com/2013/07/open-source) - Browse, analyse and decompiler IL code.
+
+* Package Management
+  * [MyGet](https://www.myget.org/opensource) - Publish public NuGet feeds of your packages for free.
+
+* Analytics and Error Reporting
+ * [Bugsnag](https://bugsnag.com/blog/bugsnag-loves-open-source) - Cross platform error reporting.
+
+* Misc
+ * [Crowdin](https://crowdin.com/page/open-source-project-setup-request) - Localisation management platform.
+ * [Transifex](https://www.transifex.com/pricing/) - Localisation management platform.


### PR DESCRIPTION
A list of services and tools that have free plans for open source .NET projects would be useful for the community (AppVeyor for CI builds, Coverity Scan for static analysis, etc.). Whilst there are some existing lists (e.g. OSS Perks), it is quite hard to identify which items are relevant to .NET development.

I've put together a starting list in this PR. Let me know what you think or if you want any changes.