### PR TITLE
Split up ImageProcessor and ImageSharp

### DIFF
--- a/dotnet-developer-projects.md
+++ b/dotnet-developer-projects.md
@@ -174,7 +174,8 @@ Please sort projects alphabetically and provide a one-line description. GitHub/C
  
 * Graphics & Server-side Image Processing
  * [DynamicImage](https://github.com/tgjones/dynamic-image) - WPF-based server-side image rendering system - lots of visual effects implemented as high-performance shaders. Has URL api, several plugins available.
- * [ImageProcessor](https://github.com/jimbobsquarepants/imageprocessor/) - A cross-platform library for processing of image files written in C#. Available in Core (NetStandard 1.1 X-Plat) and Framework (NET 4.5+ GDI+ based) flavours.
+ * [ImageSharp](https://github.com/jimbobsquarepants/imagesharp/) - A cross-platform library for processing of image files written in C#. (NetStandard 1.1 X-Plat).
+ * [ImageProcessor](https://github.com/jimbobsquarepants/imageprocessor/) - A fluent wrapper around System.Drawing for the processing of image files (NET 4.5+ GDI+ based).
  * [ImageResizer](https://github.com/imazen/resizer) - Add commands to image URLs to get altered versions in milliseconds. Edit, filter, touch-up images in real-time. (multiple backends - FreeImage, C++/CLI, GDI+, WIC). 45+ plugins available.
  * [King.Azure.Imaging](https://github.com/jefking/King.Azure.Imaging) - Scalable image uploading and processing for Azure.
  * [Magick.NET](https://magick.codeplex.com) - The .NET (Core/Framework) wrapper for the [ImageMagick](https://www.imagemagick.org) library that supports over [100 major file formats](https://www.imagemagick.org/script/formats.php).


### PR DESCRIPTION
The libraries are no longer part of the same repository so the current information is now out of date.