### PR TITLE
Change Version Reverted to correct header level for Compatibility Diagnostic

### DIFF
--- a/Documentation/compatibility/operationcontext-current-returns-null-in-a-using-clause.md
+++ b/Documentation/compatibility/operationcontext-current-returns-null-in-a-using-clause.md
@@ -6,7 +6,7 @@ Edge
 ### Version Introduced
 4.6.2
 
-## Version Reverted
+### Version Reverted
 
 ### Source Analyzer Status
 Investigating
@@ -16,28 +16,28 @@ Investigating
 <xref:System.ServiceModel.OperationContext.Current?displayProperty=fullName> may return `null` and a <xref:System.NullReferenceException> may result if all of the following conditions are true:
 
 - You retrieve the value of the <xref:System.ServiceModel.OperationContext.Current?displayProperty=fullName> property in a method that returns a <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task%601>.
- 
+
 - You instantiate the <xref:System.ServiceModel.OperationContextScope> object in a `using` clause.
 
 - You retrieve the value of the <xref:System.ServiceModel.OperationContext.Current?displayProperty=fullName> property within the `using statement`. For example:
- 
+
    ```csharp
    using (new OperationContextScope(OperationContext.Current))
    {
       OperationContext context = OperationContext.Current;      // OperationContext.Current is null.
       // ...
    }
-   ``` 
+   ```
 
-- [X] Quirked 
-- [ ] Build-time break 
+- [X] Quirked
+- [ ] Build-time break
 
 ### Recommended Action
 
 To address this issue, you can do the following:
 
 - Modify your code as follows to instantiate a new non-`null` <xref:System.ServiceModel.OperationContext.Current%2A> object:
- 
+
    ```csharp
    OperationContext ocx = OperationContext.Current;
    using (new OperationContextScope(OperationContext.Current))
@@ -48,11 +48,11 @@ To address this issue, you can do the following:
    ```
 
 - Install the latest update to the .NET Framework 4.6.2, or upgrade to a later version of the .NET Framework. This disables the flow of the <xref:System.Threading.ExecutionContext> in <xref:System.ServiceModel.OperationContext.Current?displayProperty=fullName> and restores the behavior of WCF applications in the .NET Framework 4.6.1 and earlier versions. This behavior is configurable; it is equivalent to adding the following app setting to your configuration file:
- 
+
    ```xml
    <appSettings>
       <add key="Switch.System.ServiceModel.DisableOperationContextAsyncFlow" value="true" />
-   </appSettings> 
+   </appSettings>
    ```
 
    If this change is undesirable and your application depends on execution context flowing between operation contexts, you can enable its flow as follows:
@@ -60,7 +60,7 @@ To address this issue, you can do the following:
    ```xml
    <appSettings>
       <add key="Switch.System.ServiceModel.DisableOperationContextAsyncFlow" value="false" />
-   </appSettings> 
+   </appSettings>
    ```
 
 ### Affected APIs


### PR DESCRIPTION
Incorrect header level breaks parsing in portability service.