### PR TITLE
Fixed version reverted to correct .NET Framework version

### DIFF
--- a/Documentation/compatibility/asp-net-httpruntime-appdomainapppath-throws-nullreferenceexception.md
+++ b/Documentation/compatibility/asp-net-httpruntime-appdomainapppath-throws-nullreferenceexception.md
@@ -7,7 +7,7 @@ Edge
 4.6.2
 
 ### Version Reverted
-4.6.3
+4.7
 
 ### Source Analyzer Status
 NotPlanned


### PR DESCRIPTION
The version reverted was incorrectly listed as 4.6.3; this PR changes it to 4.7

/cc @conniey @twsouthwick 