### PR TITLE
Checked quirked box, fixed bad fencing

### DIFF
--- a/Documentation/compatibility/wcf-binding-with-the-transportwithmessagecredential-security-mode.md
+++ b/Documentation/compatibility/wcf-binding-with-the-transportwithmessagecredential-security-mode.md
@@ -16,12 +16,13 @@ By default, unsigned "to" headers will continue to be rejected in .NET 4.6.1. Th
 
 Because this is an opt-in feature, it should not affect the behavior of existing apps.
 
-- [ ] Quirked
+- [X] Quirked
 - [ ] Build-time break
 
 ### Recommended Action
 Because this is an opt-in feature, it should not affect the behavior of existing apps. To control whether the new behavior is used or not, use the following configuration setting:
-```
+
+```xml
 <runtime>
     <AppContextSwitchOverrides value="Switch.System.ServiceModel.AllowUnsignedToHeader=true" />
 </runtime>

--- a/Documentation/compatibility/wcf-binding-with-the-transportwithmessagecredential-security-mode.md
+++ b/Documentation/compatibility/wcf-binding-with-the-transportwithmessagecredential-security-mode.md
@@ -10,7 +10,7 @@ Transparent
 Not planned
 
 ### Change Description
-Beginning in the .NET Framework 4.6.1, WCF binding that uses the TransportWithMessageCredential security mode can be setup to receive messages with unsigned "to" headers for asymmetric security keys.
+Beginning in the .NET Framework 4.6.1, WCF binding that uses the TransportWithMessageCredential security mode can be set up to receive messages with unsigned "to" headers for asymmetric security keys.
 
 By default, unsigned "to" headers will continue to be rejected in .NET 4.6.1. They will only be accepted if an application opts into this new mode of operation using the Switch.System.ServiceModel.AllowUnsignedToHeader configuration switch.
 


### PR DESCRIPTION

//cc @conniey, because retargeting wasn't selected, this appears in the list of runtime changes. Can you remigrate to dotnet/docs?

