### PR TITLE
Update 510901-BCL Apps targeting .NET-4.6.1 that use .NET Standard li…

### DIFF
--- a/releases/net471/KnownIssues/510901-BCL Apps targeting .NET-4.6.1 that use .NET Standard libraries might be broken when running on .NET 4.7.1.md
+++ b/releases/net471/KnownIssues/510901-BCL Apps targeting .NET-4.6.1 that use .NET Standard libraries might be broken when running on .NET 4.7.1.md
@@ -54,5 +54,5 @@ The following types are potentially impacted by this issue.
 
 There are two ways to work around this issue:
  - When running on .NET Framework 4.7.1, remove the binding redirects from the app.config file for the assemblies that are now part of the .NET Framework.
- - Re-target your application to target the .NET Framwork 4.7.1
+ - Re-target your application to target the .NET Framwork 4.7 or .NET Framework 4.7.1.
  


### PR DESCRIPTION
…braries might be broken when running on .NET 4.7.1.md

@rpetrusha @vivmishra 