### PR TITLE
Update 521954 - BCL CultureAwareComparer with ignore casing on serial…

### DIFF
--- a/releases/net471/KnownIssues/521954 - BCL CultureAwareComparer with ignore casing on serialized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md
+++ b/releases/net471/KnownIssues/521954 - BCL CultureAwareComparer with ignore casing on serialized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md
@@ -21,4 +21,4 @@ P:System.StringComparer.CurrentCultureIgnoreCase
 
 Ensure that both serialization and deserialization occurs on systems running a version of the .NET Framework starting with 4.7.1.
 
-We are actively working on a patch to address this issue and we will update this document with a link to it once it becomes available.
+We are actively working on an update to address this issue and we will update this document with a link to it once it becomes available.

--- a/releases/net471/KnownIssues/521954 - BCL CultureAwareComparer with ignore casing on serialized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md
+++ b/releases/net471/KnownIssues/521954 - BCL CultureAwareComparer with ignore casing on serialized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md
@@ -20,3 +20,5 @@ P:System.StringComparer.CurrentCultureIgnoreCase
 ## Workarounds
 
 Ensure that both serialization and deserialization occurs on systems running a version of the .NET Framework starting with 4.7.1.
+
+We are actively working on a patch to address this issue and we will update this document with a link to it once it becomes available.


### PR DESCRIPTION
…ized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md

/cc @vivmishra @HeathAr @preetikr 