### PR TITLE
Update 521954 - BCL CultureAwareComparer with ignore casing on serial…

### DIFF
--- a/releases/net471/KnownIssues/521954 - BCL CultureAwareComparer with ignore casing on serialized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md
+++ b/releases/net471/KnownIssues/521954 - BCL CultureAwareComparer with ignore casing on serialized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md
@@ -21,4 +21,8 @@ P:System.StringComparer.CurrentCultureIgnoreCase
 
 Ensure that both serialization and deserialization occurs on systems running a version of the .NET Framework starting with 4.7.1.
 
-We are actively working on an update to address this issue and we will update this document with a link to it once it becomes available.
+If you are running on Windows Fall Creators Update you can use the following links to install an update that will address this issue. Please select the corresponding link based on the processor architecture:
+
+x86: https://go.microsoft.com/fwlink/?linkid=862758
+
+x64: https://go.microsoft.com/fwlink/?linkid=862762


### PR DESCRIPTION
…ized on previous versions of .NET do not correctly deserialize on .NET 4.7.1.md

/cc @vivmishra @HeathAr @preetikr 