### PR TITLE
Changes so content syncs with PR #3686 in dotnet/docs

### DIFF
--- a/Documentation/compatibility/no-longer-able-to-set-enableviewstatemac-to-false.md
+++ b/Documentation/compatibility/no-longer-able-to-set-enableviewstatemac-to-false.md
@@ -10,13 +10,13 @@ Major
 Available
 
 ### Change Description
-ASP.NET no longer allows developers to specify `<pages enableViewStateMac="false"/>` or `<@Page EnableViewStateMac="false" %>`. The view state message authentication code (MAC) is now enforced for all requests with embedded view state. Only apps that explicitly set the EnableViewStateMac property to false are affected.
+ASP.NET no longer allows developers to specify `<pages enableViewStateMac="false"/>` or `<@Page EnableViewStateMac="false" %>`. The view state message authentication code (MAC) is now enforced for all requests with embedded view state. Only apps that explicitly set the EnableViewStateMac property to `false` are affected.
 
 - [ ] Quirked
 - [ ] Build-time break
 
 ### Recommended Action
-EnableViewStateMac must be assumed to be true, and any resulting MAC errors must be resolved (as explained in [this](https://support.microsoft.com/en-us/kb/2915218) guidance, which contains multiple resolutions depending on the specifics of what is causing MAC errors).
+EnableViewStateMac must be assumed to be true, and any resulting MAC errors must be resolved (as explained in [this guidance](https://support.microsoft.com/en-us/kb/2915218), which contains multiple resolutions depending on the specifics of what is causing MAC errors).
 
 ### Affected APIs
 * Not detectable via API analysis


### PR DESCRIPTION
In [PR 3686](https://github.com/dotnet/docs/pull/3686) in the dotnet/docs repo, @mairaw made a number of changes to an app compat topic. Some of corrected bad encodings  introduced during migration; others were improvements or corrections. This PR adds the improvements and corrections to the topic in the Microsoft/dotnet repo. 

//cc @conniey 