### PR TITLE
Converted asset IDs to xrefs, corrected formatting

### DIFF
--- a/Documentation/compatibility/data-written-to-printsystemjobinfo-jobstream-must-be-in-xps-format.md
+++ b/Documentation/compatibility/data-written-to-printsystemjobinfo-jobstream-must-be-in-xps-format.md
@@ -10,7 +10,7 @@ Minor
 NotPlanned
 
 ### Change Description
-The `P:System.Printing.PrintSystemJobInfo.JobStream` property exposes the stream of a print job. The user can send raw data to the underlying operating system printing components by writing to this stream.
+The <xref:System.Printing.PrintSystemJobInfo.JobStream> property exposes the stream of a print job. The user can send raw data to the underlying operating system printing components by writing to this stream.
 
 Starting with the .NET Framework 4.5 on Windows 8 and later versions of the Windows operating system, data written to this stream must be in XPS format as a package stream.
   
@@ -21,9 +21,9 @@ Starting with the .NET Framework 4.5 on Windows 8 and later versions of the Wind
 
 To output print content, you can do either of the following:
 
-- Use the `T:System.Windows.Xps.XpsDocumentWriter` class to output print content. This is the recommended alternative.
+- Use the <xref:System.Windows.Xps.XpsDocumentWriter> class to output print content. This is the recommended alternative.
 
-- Ensure that the data sent to the stream returned by the `P:System.Printing.PrintSystemJobInfo.JobStream` property is in XPS format as a package stream.  
+- Ensure that the data sent to the stream returned by the <xref:System.Printing.PrintSystemJobInfo.JobStream> property is in XPS format as a package stream.  
 
 ### Affected APIs
 * `P:System.Printing.PrintSystemJobInfo.JobStream`

--- a/Documentation/compatibility/serialization-deserialization-of-mailmessage-objects.md
+++ b/Documentation/compatibility/serialization-deserialization-of-mailmessage-objects.md
@@ -10,17 +10,17 @@ Minor
 Investigating
 
 ### Change Description
-Starting with the .NET Framework 4.5, `T:System.Web.Mail.MailMessage` objects can include non-ASCII characters. In the .NET Framework 4, only ASCII characters are supported. `T:System.Web.Mail.MailMessage` objects that contain non-ASCII characters and that are serialized under the .NET Framework 4.5 or later cannot be deserialized under the .NET Framework 4. 
+Starting with the .NET Framework 4.5, <xref:System.Web.Mail.MailMessage> objects can include non-ASCII characters. In the .NET Framework 4, only ASCII characters are supported. <xref:System.Web.Mail.MailMessage> objects that contain non-ASCII characters and that are serialized under the .NET Framework 4.5 or later cannot be deserialized under the .NET Framework 4. 
 
 - [ ] Quirked 
 - [ ] Build-time break 
 
 ### Recommended Action
 
-Ensure that your code provides exception handling when deserializing a `T:System.Web.Mail.MailMessage` object.
+Ensure that your code provides exception handling when deserializing a <xref:System.Web.Mail.MailMessage> object.
 
 ### Affected APIs
-`T:System.Web.Mail.MailMessage`
+<xref:System.Web.Mail.MailMessage>
 
 ### Category
 Networking

--- a/Documentation/compatibility/winforms-accessibility-changes-471.md
+++ b/Documentation/compatibility/winforms-accessibility-changes-471.md
@@ -106,10 +106,10 @@ NOTE: Windows10 has changed values for some high contrast system colors. Windows
 - Narrator is now able to read `T:System.Windows.Forms.ToolStripMenuItem` controls with a `P:System.Windows.Forms.ToolStripItem.Enabled` property set to _false_. Previously, Narrator was unable to focus on disabled menu items to read hte content. 
 
 
-### Affected APIs not detectable via API analysis
+### Affected APIs
 * `M:System.Windows.Forms.ToolStripDropDownButton.CreateAccessibilityInstance`
 * `P:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.Name`
-* `T:Sysetm.Windows.Forms.MonthCalendar.MonthCalendarAccessibleObject` 
+* `T:System.Windows.Forms.MonthCalendar.MonthCalendarAccessibleObject` 
 
 
 ### Category

--- a/Documentation/compatibility/workflow-designer-accessibility.md
+++ b/Documentation/compatibility/workflow-designer-accessibility.md
@@ -12,8 +12,8 @@ NotPlanned
 ### Change Description
 The Windows Workflow Foundation (WF) workflow designer is improving how it works with accessibility technologies. These improvements include the following changes:
 - The tab order is changed to left to right and top to bottom in some controls:
-  - The initialize correlation window for setting correlation data for the `T:System.ServiceModel.Activities.InitializeCorrelation` activity
-  - The content definition window for the `T:System.ServiceModel.Activities.Receive`, `T:System.ServiceModel.Activities.Send`, `T:System.ServiceModel.Activities.SendReply`, and `T:System.ServiceModel.Activities.ReceiveReply` activities
+  - The initialize correlation window for setting correlation data for the <xref:System.ServiceModel.Activities.InitializeCorrelation> activity
+  - The content definition window for the <xref:System.ServiceModel.Activities.Receive>, <xref:System.ServiceModel.Activities.Send>, <xref:System.ServiceModel.Activities.SendReply>, and <xref:System.ServiceModel.Activities.ReceiveReply> activities
 - More functions are available via the keyboard:
   - When editing the properties of an activity, property groups can be collapsed by keyboard the first time they are focused.
   - Warning icons are now accessible by keyboard.
@@ -21,23 +21,23 @@ The Windows Workflow Foundation (WF) workflow designer is improving how it works
   - Keyboard users now can access the header items in the Arguments and Variables panes of the Workflow Designer.
 - Improved visibility of items with focus, such as when:
   - Adding rows to data grids used by the Workflow Designer and activity designers.
-  - Tabbing through fields in the `T:System.ServiceModel.Activities.ReceiveReply` and `T:System.ServiceModel.Activities.SendReply` activities.
+  - Tabbing through fields in the <xref:System.ServiceModel.Activities.ReceiveReply> and <xref:System.ServiceModel.Activities.SendReply> activities.
   - Setting default values for variables or arguments
 - Screen readers can now correctly recognize:
   - Breakpoints set in the workflow designer.
-  - The `T:System.Activities.Statements.FlowSwitch`, `T:System.Activities.Statements.FlowDecision`, and `T:System.ServiceModel.Activities.CorrelationScope` activities.
-  - The contents of the `T:System.ServiceModel.Activities.Receive` activity.
-  - The Target Type for the `T:System.Activities.Statements.InvokeMethod` activity.
-  - The Exception combobox and the Finally section in the `T:System.Activities.Statements.TryCatch` activity.
-  - The Message Type combobox, the splitter in the Add Correlation Initializers window, the Content Definition window, and the CorrelatesOn Defintion window in the messaging activities (`T:System.ServiceModel.Activities.Receive`, `T:System.ServiceModel.Activities.Send`, `T:System.ServiceModel.Activities.SendReply`, and `T:System.ServiceModel.Activities.ReceiveReply`).
+  - The <xref:System.Activities.Statements.FlowSwitch>, <xref:System.Activities.Statements.FlowDecision>, and <xref:System.ServiceModel.Activities.CorrelationScope> activities.
+  - The contents of the <xref:System.ServiceModel.Activities.Receive> activity.
+  - The Target Type for the <xref:System.Activities.Statements.InvokeMethod> activity.
+  - The Exception combobox and the Finally section in the <xref:System.Activities.Statements.TryCatch> activity.
+  - The Message Type combobox, the splitter in the Add Correlation Initializers window, the Content Definition window, and the CorrelatesOn Defintion window in the messaging activities (<xref:System.ServiceModel.Activities.Receive>, <xref:System.ServiceModel.Activities.Send>, <xref:System.ServiceModel.Activities.SendReply>, and <xref:System.ServiceModel.Activities.ReceiveReply>).
   - State machine transitions and transitions destinations.
-  - Annotations and connectors on `T:System.Activities.Statements.FlowDecision` activities.
+  - Annotations and connectors on <xref:System.Activities.Statements.FlowDecision> activities.
   - The context (right-click) menus for activities.
   - The property value editors, the Clear Search button, the By Category and Alphabetical sort buttons, and the Expression Editor dialog in the properties grid.
   - The zoom percentage in the Workflow Designer.
-  - The separator in `T:System.Activities.Statements.Parallel` and `T:System.Activities.Statements.Pick` activities.
-  - The `T:System.Activities.Statements.InvokeDelegate` activity.
-  - The Select Types window for dictionary activities (`T:Microsoft.Activities.AddToDictionary`, `T:Microsoft.Activities.RemoveFromDictionary`, etc.).
+  - The separator in <xref:System.Activities.Statements.Parallel> and <xref:System.Activities.Statements.Pick> activities.
+  - The <xref:System.Activities.Statements.InvokeDelegate> activity.
+  - The Select Types window for dictionary activities (<xref:Microsoft.Activities.AddToDictionary>, <xref:Microsoft.Activities.RemoveFromDictionary>, etc.).
   - The Browse and Select .NET Type window.
   - Breadcrumbs in the Workflow Designer.
 - Users who choose High Contrast themes will see many improvements in the visibility of the Workflow Designer and its controls like better contrast ratios between elements and more noticeable selection boxes used for focus elements.

--- a/Documentation/compatibility/wpf-accessibility-improvements.MD
+++ b/Documentation/compatibility/wpf-accessibility-improvements.MD
@@ -12,27 +12,27 @@ NotPlanned
 ### Change Description
 __High Contrast improvements__
 
-- The focus for the `T:System.Windows.Controls.Expander` control is now visible. In previous versions of the .NET Framework, it was not.
-- The text in `T:System.Windows.Controls.CheckBox` and `T:System.Windows.Controls.RadioButton` controls when they are selected is now easier to see than in previous .NET Framework versions.
-- The border of a disabled `T:System.Windows.Controls.ComboBox` is now the same color as the disabled text. In previous versions of the .NET Framework, it was not.
+- The focus for the <xref:System.Windows.Controls.Expander> control is now visible. In previous versions of the .NET Framework, it was not.
+- The text in <xref:System.Windows.Controls.CheckBox> and <xref:System.Windows.Controls.RadioButton> controls when they are selected is now easier to see than in previous .NET Framework versions.
+- The border of a disabled <xref:System.Windows.Controls.ComboBox> is now the same color as the disabled text. In previous versions of the .NET Framework, it was not.
 - Disabled and focused buttons now use the correct theme color. In previous versions of the .NET Framework, they did not.
-- The dropdown button is now visible when a `T:System.Windows.Controls.ComboBox` control's style is set to <xref:System.Windows.Controls.ToolBar.ComboBoxStyleKey?displayProperty=typeWithName>, In previous versions of the .NET Framework, it was not.
-- The sort indicator arrow in a `T:System.Windows.Controls.DataGrid` control now uses theme colors. In previous versions of the .NET Framework, it did not.
+- The dropdown button is now visible when a <xref:System.Windows.Controls.ComboBox> control's style is set to <xref:System.Windows.Controls.ToolBar.ComboBoxStyleKey?displayProperty=nameWithType>, In previous versions of the .NET Framework, it was not.
+- The sort indicator arrow in a <xref:System.Windows.Controls.DataGrid> control now uses theme colors. In previous versions of the .NET Framework, it did not.
 - The default hyperlink style now changes to the correct theme color on mouse over. In previous versions of the .NET Framework, it did not.
 - The Keyboard focus on radio buttons is now visible. In previous versions of the .NET Framework, it was not.
-- The `T:System.Windows.Controls.DataGrid` control's checkbox column now uses the expected colors for keyboard focus feedback. In previous versions of the .NET Framework, it did not.
-- the Keyboard focus visuals are now visible on `T:System.Windows.Controls.ComboBox` and `T:System.Windows.Controls.ListBox`. In previous versions of the .NET Framework, it was not.
+- The <xref:System.Windows.Controls.DataGrid> control's checkbox column now uses the expected colors for keyboard focus feedback. In previous versions of the .NET Framework, it did not.
+- the Keyboard focus visuals are now visible on <xref:System.Windows.Controls.ComboBox> and <xref:System.Windows.Controls.ListBox>. In previous versions of the .NET Framework, it was not.
 
 
 __Screen reader interaction improvements__
 
-- `T:System.Windows.Controls.Expander` controls are now correctly announced as groups (expand/collapse) by screen readers.
-- `T:System.Windows.Controls.DataGridCell` controls are now correctly announced as data grid cell (localized) by screen readers.
-- Screen readers will now announce the name of an editable `T:System.Windows.Controls.ComboBox`.
-- `T:System.Windows.Controls.PasswordBox` controls are no longer announced as “no item in view” by screen readers.
+- <xref:System.Windows.Controls.Expander> controls are now correctly announced as groups (expand/collapse) by screen readers.
+- <xref:System.Windows.Controls.DataGridCell> controls are now correctly announced as data grid cell (localized) by screen readers.
+- Screen readers will now announce the name of an editable <xref:System.Windows.Controls.ComboBox>.
+- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as “no item in view” by screen readers.
 
 
-__LiveRegion support__
+__LiveRegion support__   
 
 Screen readers such as Narrator help people know the UI contents of an application, usually by describing something about the UI that’s currently focused, because that is probably the element of most interest to the user. However, if a UI element changes somewhere in the screen and it does not have the focus, the user may not be informed and miss important information.
 LiveRegions are meant to solve this problem. A developer can use them to inform the screen reader or any other [UI Automation][UI Automation Overview](https://docs.microsoft.com/dotnet/framework/ui-automation/ui-automation-overview) client that an important change has been made to a UI element. The screen reader can then decide how and when to inform the user of this change.
@@ -47,7 +47,7 @@ __How to opt in or out of these changes__
 
 In order for the application to benefit from these changes, it must run on the .NET Framework 4.7.1 or later. The application can benefit from these changes in either of the following ways:
 - It is recompiled to target the .NET Framework 4.7.1. These accessibility changes are enabled by default on WPF applications that target the .NET Framework 4.7.1 or later.
-- It opts out of the legacy accessibility behaviors by adding the following [AppContext Switch](https://docs.microsoft.com/dotnet/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element) in the ```<runtime>``` section of the app config file and setting it to false, as the following example shows.
+- It opts out of the legacy accessibility behaviors by adding the following [AppContext Switch](https://docs.microsoft.com/dotnet/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element) in the `<runtime>` section of the app config file and setting it to false, as the following example shows.
 ```
     <?xml version="1.0" encoding="utf-8"?>
     <configuration>

--- a/Documentation/compatibility/wpf-tabcontrol-selectionchanged-and-selectedcontent.md
+++ b/Documentation/compatibility/wpf-tabcontrol-selectionchanged-and-selectedcontent.md
@@ -10,9 +10,9 @@ Minor
 NotPlanned
 
 ### Change Description
-Starting with the .NET Framework 4.7.1, a `T:System.Windows.Controls.TabControl` updates the value of its
-`P:System.Windows.Controls.TabControl.SelectedContent` property before raising the
-`E:System.Windows.Controls.Primitives.Selector.SelectionChanged` event, when its selection changes.
+Starting with the .NET Framework 4.7.1, a <xref:System.Windows.Controls.TabControl> updates the value of its
+<xref:System.Windows.Controls.TabControl.SelectedContent> property before raising the
+<xref:System.Windows.Controls.Primitives.Selector.SelectionChanged> event, when its selection changes.
 
 In the .NET Framework 4.7 and earlier versions, the update to SelectedContent happened after the event.
 


### PR DESCRIPTION
The compatibility topics in the dotnet/docs repo continue to show asset IDs, which are not resolved to links. This PR should allow the build system to convert them to links.

I'll open a separate PR in the dotnet/docs repo to make parallel changes to the topics.

//cc @conniey 
