### PR TITLE
Replaced unprintable characters.

### DIFF
--- a/Documentation/compatibility/wpf-accessibility-improvements.MD
+++ b/Documentation/compatibility/wpf-accessibility-improvements.MD
@@ -29,12 +29,12 @@ __Screen reader interaction improvements__
 - <xref:System.Windows.Controls.Expander> controls are now correctly announced as groups (expand/collapse) by screen readers.
 - <xref:System.Windows.Controls.DataGridCell> controls are now correctly announced as data grid cell (localized) by screen readers.
 - Screen readers will now announce the name of an editable <xref:System.Windows.Controls.ComboBox>.
-- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as “no item in view” by screen readers.
+- <xref:System.Windows.Controls.PasswordBox> controls are no longer announced as "no item in view" by screen readers.
 
 
 __LiveRegion support__   
 
-Screen readers such as Narrator help people know the UI contents of an application, usually by describing something about the UI that’s currently focused, because that is probably the element of most interest to the user. However, if a UI element changes somewhere in the screen and it does not have the focus, the user may not be informed and miss important information.
+Screen readers such as Narrator help people know the UI contents of an application, usually by describing something about the UI that's currently focused, because that is probably the element of most interest to the user. However, if a UI element changes somewhere in the screen and it does not have the focus, the user may not be informed and miss important information.
 LiveRegions are meant to solve this problem. A developer can use them to inform the screen reader or any other [UI Automation][UI Automation Overview](https://docs.microsoft.com/dotnet/framework/ui-automation/ui-automation-overview) client that an important change has been made to a UI element. The screen reader can then decide how and when to inform the user of this change.
 The LiveSetting property also lets the screen reader know how important it is to inform the user of the change made to the UI.
 


### PR DESCRIPTION
The quotation mark and apostrophe symbols were not correctly rendering in docs; this was fixed in PR 3924 in the dotnet/docs repo, so that this content does not have to be specially re-migrated.