### PR TITLE
Add known issue for 470006 - GC large object crashes

### DIFF
--- a/releases/net471/KnownIssues/470006-GC Crashes with high rate of large object allocation.md
+++ b/releases/net471/KnownIssues/470006-GC Crashes with high rate of large object allocation.md
@@ -1,0 +1,36 @@
+# Rare crashes can occur when background GC is enabled in applications which allocate and free large objects at a high rate
+
+## Symptoms
+
+When background GC is enabled, an application running against .NET Framework 4.7.1 experiences
+intermittent crashes which did not occur when running against other .NET Framework versions.
+
+## Cause
+
+Changes to the GC in .NET Framework 4.7.1 caused this problem.
+
+Specifically, .NET Framework 4.7.1 contains changes which improve background GC performance.
+These changes unintentionally introduced cases where a rare combination of factors can cause
+the background GC to reclaim a large object while the program is still using it.
+
+## Impact
+
+This problem impacts applications which run with the background GC enabled and which also allocate
+and free large objects at a high rate. As described in [this article](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap),
+a large object is any object that is 85,000 bytes or larger in size.
+
+This problem is rare, and is more likely to occur when running against the x86 version of the
+.NET Framework than when running against the x64 version of the .NET Framework.
+
+## Workarounds
+
+The most practical workaround is to disable the background GC using the configuration file
+elements described in [this article](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcconcurrent-element).
+
+The only other workaround is to change the application to allocate and free large objects
+at a much lower rate.
+
+## Resolution
+
+This problem is fixed in .NET Framework 4.7.2.
+

--- a/releases/net471/KnownIssues/470006-GC Crashes with high rate of large object allocation.md
+++ b/releases/net471/KnownIssues/470006-GC Crashes with high rate of large object allocation.md
@@ -1,36 +1,34 @@
-# Rare crashes can occur when background GC is enabled in applications which allocate and free large objects at a high rate
+# Rare crashes can occur when background GC is enabled in applications that allocate and free large objects at a high rate
 
 ## Symptoms
 
-When background GC is enabled, an application running against .NET Framework 4.7.1 experiences
-intermittent crashes which did not occur when running against other .NET Framework versions.
+When background GC is enabled, an application running on .NET Framework 4.7.1 experiences
+intermittent crashes that did not occur when running on other .NET Framework versions.
 
 ## Cause
 
-Changes to the GC in .NET Framework 4.7.1 caused this problem.
-
-Specifically, .NET Framework 4.7.1 contains changes which improve background GC performance.
-These changes unintentionally introduced cases where a rare combination of factors can cause
-the background GC to reclaim a large object while the program is still using it.
+.NET Framework 4.7.1 includes changes that improve background GC performance.
+Because of these changes, a rare combination of factors can cause the background GC
+to reclaim a large object while the program is still using it.
 
 ## Impact
 
-This problem impacts applications which run with the background GC enabled and which also allocate
-and free large objects at a high rate. As described in [this article](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap),
+This problem impacts applications that run with the background GC enabled and that also allocate
+and free large objects at a high rate. As described in the article [Fundamentals of Garbage Collection](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals#the-managed-heap),
 a large object is any object that is 85,000 bytes or larger in size.
 
-This problem is rare, and is more likely to occur when running against the x86 version of the
-.NET Framework than when running against the x64 version of the .NET Framework.
+This problem is rare, and is more likely to occur when running on the x86 version of the
+.NET Framework than when running on the x64 version of the 4.7.1 .NET Framework.
 
 ## Workarounds
 
-The most practical workaround is to disable the background GC using the configuration file
-elements described in [this article](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcconcurrent-element).
-
+The most practical workaround is to disable the background GC by setting the enabled attribute of the [<gcConcurrent> element](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/gcconcurrent-element) in the
+  <runtime> section of your application configuration file to false.
+    
 The only other workaround is to change the application to allocate and free large objects
 at a much lower rate.
 
 ## Resolution
 
-This problem is fixed in .NET Framework 4.7.2.
+This problem is fixed in [.NET Framework 4.7.2](http://go.microsoft.com/fwlink/?LinkId=863281).
 

--- a/releases/net471/dotnet471-known-issues.md
+++ b/releases/net471/dotnet471-known-issues.md
@@ -4,7 +4,7 @@
 This document lists the known issues that you may experience after you install the Microsoft .NET Framework 4.7.1.   
 
 ## Product issues for the .NET Framework 4.7.1   
-- [470006 - GC - Rare crashes can occur when background GC is enabled in applications which allocate and free large objects at a high rate](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/470006-GC%20Crashes%20with%20high%20rate%20of%20large%20object%20allocation.md)
+- [470006 - GC - Rare crashes can occur when background GC is enabled in applications that allocate and free large objects at a high rate](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/470006-GC%20Crashes%20with%20high%20rate%20of%20large%20object%20allocation.md)
 - [479874 - WPF - Touch Stops Working After Rapid/Prolonged Use Of Popups](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/479874-WPF%20Touch%20Stops%20Working%20After%20Prolonged%20Use%20of%20Popups.md)
 - [481090 - WPF - Touch generates a NullReferenceException in WispLogic.ProcessInputReport](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/481090-WPF%20Touch%20generates%20NullReferenceException%20in%20ProcessInputReport.md)
 - [489937 - WPF - Touch/Stylus Generates AccessViolations and Heap Corruption in GetPenEventMultiple](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/489937-WPF%20Touch%20and%20Stylus%20AccessViolation%20in%20GetPenEventMultiple.md)

--- a/releases/net471/dotnet471-known-issues.md
+++ b/releases/net471/dotnet471-known-issues.md
@@ -4,6 +4,7 @@
 This document lists the known issues that you may experience after you install the Microsoft .NET Framework 4.7.1.   
 
 ## Product issues for the .NET Framework 4.7.1   
+- [470006 - GC - Rare crashes can occur when background GC is enabled in applications which allocate and free large objects at a high rate](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/470006-GC%20Crashes%20with%20high%20rate%20of%20large%20object%20allocation.md)
 - [479874 - WPF - Touch Stops Working After Rapid/Prolonged Use Of Popups](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/479874-WPF%20Touch%20Stops%20Working%20After%20Prolonged%20Use%20of%20Popups.md)
 - [481090 - WPF - Touch generates a NullReferenceException in WispLogic.ProcessInputReport](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/481090-WPF%20Touch%20generates%20NullReferenceException%20in%20ProcessInputReport.md)
 - [489937 - WPF - Touch/Stylus Generates AccessViolations and Heap Corruption in GetPenEventMultiple](https://github.com/Microsoft/dotnet/blob/master/releases/net471/KnownIssues/489937-WPF%20Touch%20and%20Stylus%20AccessViolation%20in%20GetPenEventMultiple.md)


### PR DESCRIPTION
Added a known issue, written by Chris Ahna, about GC crashes when we
have a high rate of large object allocations and frees.