### PR TITLE
fixed formatting 

### DIFF
--- a/Documentation/compatibility/asp_net-mvc-now-escapes-spaces-in-strings-passed-in-via-route-parameters.md
+++ b/Documentation/compatibility/asp_net-mvc-now-escapes-spaces-in-strings-passed-in-via-route-parameters.md
@@ -19,7 +19,7 @@ In order to conform to RFC 2396, spaces in route paths are now escaped when popu
 Code should be updated to unescape string parameters from a route. If the original URI is needed, it can be accessed with the <xref:System.Net.HttpWebRequest.RequestUri>.OriginalString API.
 
 ### Affected APIs
-* `M:System.Web.Http.RouteAttribute.#ctor(System.String)`
+* `M:System.Web.Http.RouteAttribute.%23ctor(System.String)`
 
 ### Category
 ASP.NET

--- a/Documentation/compatibility/remove-ssl3-from-the-wcf-transportdefaults.md
+++ b/Documentation/compatibility/remove-ssl3-from-the-wcf-transportdefaults.md
@@ -27,8 +27,8 @@ Ssl3 to the list of negotiated protocols.
 
 * <xref:System.ServiceModel.Channels.SslStreamSecurityBindingElement.SslProtocols>
 * <xref:System.ServiceModel.TcpTransportSecurity.SslProtocols>
-* [\<transport\> section of \<netTcpBinding\>](https://docs.microsoft.com/en-us/dotnet/articles/framework/configure-apps/file-schema/wcf/transport-of-nettcpbinding)
-* [\<sslStreamSecurity\> section of \<customBinding\>](https://docs.microsoft.com/en-us/dotnet/articles/framework/configure-apps/file-schema/wcf/sslstreamsecurity)
+* [\<transport> section of \<netTcpBinding>](https://docs.microsoft.com/en-us/dotnet/articles/framework/configure-apps/file-schema/wcf/transport-of-nettcpbinding)
+* [\<sslStreamSecurity> section of \<customBinding>](https://docs.microsoft.com/en-us/dotnet/articles/framework/configure-apps/file-schema/wcf/sslstreamsecurity)
 
 ### Affected APIs
 * `P:System.ServiceModel.Channels.SslStreamSecurityBindingElement.SslProtocols`

--- a/Documentation/compatibility/winforms-accessibility-changes-471.md
+++ b/Documentation/compatibility/winforms-accessibility-changes-471.md
@@ -1,4 +1,4 @@
-## Accessibility improvements in Windows Forms controls
+﻿## Accessibility improvements in Windows Forms controls
 
 ### Scope
 Major
@@ -109,7 +109,7 @@ NOTE: Windows10 has changed values for some high contrast system colors. Windows
 ### Affected APIs
 * `M:System.Windows.Forms.ToolStripDropDownButton.CreateAccessibilityInstance`
 * `P:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.Name`
-* `T:System.Windows.Forms.MonthCalendar.MonthCalendarAccessibleObject` 
+* `T:System.Windows.Forms.MonthCalendar.AccessibilityObject` 
 
 
 ### Category

--- a/Documentation/compatibility/wpf-selector-selectionchanged-and-selectedvalue.md
+++ b/Documentation/compatibility/wpf-selector-selectionchanged-and-selectedvalue.md
@@ -12,7 +12,7 @@ NotPlanned
 ### Change Description
 Starting with the .Net Framework 4.7.1, a <xref:System.Windows.Controls.Primitives.Selector> always updates the value of its
 <xref:System.Windows.Controls.Primitives.Selector.SelectedValue%2A> property before raising the
-<xref:System.Windows.Controls.Primitives.Selector.SelectionChanged%2A> event, when its selection changes.
+<xref:System.Windows.Controls.Primitives.Selector.SelectionChanged> event, when its selection changes.
 This makes the SelectedValue property consistent with the other selection properties 
 (<xref:System.Windows.Controls.Primitives.Selector.SelectedItem%2A> and 
 <xref:System.Windows.Controls.Primitives.Selector.SelectedIndex%2A>), which are updated before raising the event.  


### PR DESCRIPTION
Hopefully this corrects the formatting; the last two items appear only as `\<` and `\<`.
