### PR TITLE
Update known issue 517815-BCL Stack traces are missing source information

### DIFF
--- a/releases/net471/KnownIssues/517815-BCL Stack traces are missing source information for frames with debug information in the Portable PDB format.md
+++ b/releases/net471/KnownIssues/517815-BCL Stack traces are missing source information for frames with debug information in the Portable PDB format.md
@@ -1,3 +1,4 @@
+
 # Stack traces are missing source information for frames with debug information in the Portable PDB format when running on .NET Framework 4.7.1
 
 ## Symptoms
@@ -12,6 +13,7 @@ The .NET Framework 4.7.1 added support for detecting and parsing the Portable PD
 ## Workarounds
 
 - If you control the build process for the problematic assemblies you may be able to configure it to generate the classic Windows PDB format instead.
+- You could use the [PDB conversion tool](https://github.com/dotnet/symreader-converter) to convert the Portable PDBs into the classic Windows PDB format and deploy those with the application instead.
 
 ## Resolution
 

--- a/releases/net471/KnownIssues/517815-BCL Stack traces are missing source information for frames with debug information in the Portable PDB format.md
+++ b/releases/net471/KnownIssues/517815-BCL Stack traces are missing source information for frames with debug information in the Portable PDB format.md
@@ -13,8 +13,8 @@ The .NET Framework 4.7.1 added support for detecting and parsing the Portable PD
 ## Workarounds
 
 - If you control the build process for the problematic assemblies you may be able to configure it to generate the classic Windows PDB format instead.
-- You could use the [PDB conversion tool](https://github.com/dotnet/symreader-converter) to convert the Portable PDBs into the classic Windows PDB format and deploy those with the application instead.
+- You can use the [PDB conversion tool](https://github.com/dotnet/symreader-converter) to convert the Portable PDBs into the classic Windows PDB format and deploy those with the application instead.
 
 ## Resolution
 
-A fix is anticipated in .NET Framework 4.7.2, in the near future, that restores Portable PDB functionality with greatly improved performance.
+A fix is anticipated in .NET Framework 4.7.2 in the near future that restores Portable PDB functionality with greatly improved performance.


### PR DESCRIPTION
Add the portable PDB conversion tool as a workaround now that it is better documented how to use it.