### PR TITLE
Fix compat doc links

### DIFF
--- a/Documentation/compatibility/application_filtermessage-no-longer-throws-for-re-entrant-implementations-of-imessagefilter_prefiltermessage.md
+++ b/Documentation/compatibility/application_filtermessage-no-longer-throws-for-re-entrant-implementations-of-imessagefilter_prefiltermessage.md
@@ -38,7 +38,7 @@ Framework 4.6.1.
 
 Apps targeting the .NET Framework 4.6.1 can opt out of this change (or apps
 targeting older Frameworks may opt in) by using the
-[DontSupportReentrantFilterMessage](~/docs/framework/migration-guide/mitigation-custom-imessagefilter-prefiltermessage-implementations#mitigation.md)
+[DontSupportReentrantFilterMessage](~/docs/framework/migration-guide/mitigation-custom-imessagefilter-prefiltermessage-implementations#mitigation)
 compatibility switch.
 
 ### Affected APIs

--- a/Documentation/compatibility/certificate-eku-oid-validation.md
+++ b/Documentation/compatibility/certificate-eku-oid-validation.md
@@ -11,25 +11,25 @@ NotPlanned
 
 ### Change Description
 
-Starting with .NET Framework 4.6, the <xref:System.Net.Security.SslStream> or <xref:System.Net.ServicePointManager> classes perform enhanced key use (EKU) object identifier (OID) validation. An enhanced key usage (EKU) extension is a collection of object identifiers (OIDs) that indicate the applications that use the key. EKU OID validation uses remote certificate callbacks to ensure that the remote certificate has the correct OIDs for the intended purpose.  
+Starting with .NET Framework 4.6, the <xref:System.Net.Security.SslStream> or <xref:System.Net.ServicePointManager> classes perform enhanced key use (EKU) object identifier (OID) validation. An enhanced key usage (EKU) extension is a collection of object identifiers (OIDs) that indicate the applications that use the key. EKU OID validation uses remote certificate callbacks to ensure that the remote certificate has the correct OIDs for the intended purpose.
 
-- [X] Quirked 
+- [X] Quirked
 - [ ] Build-time break
 
 ### Recommended Action
 
-If this change is undesirable, you can disable certificate EKU OID validation by adding the following switch to the [`\<AppContextSwitchOverrides>` element](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) in the [`\<runtime> section](~/docsframework/configure-apps/file-schema/runtime/runtime-element.md) of your app configuration file:
+If this change is undesirable, you can disable certificate EKU OID validation by adding the following switch to the [`\<AppContextSwitchOverrides>` element](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) in the [`\<runtime> section](~/docs/framework/configure-apps/file-schema/runtime/runtime-element.md) of your app configuration file:
 
 ```xml
 <runtime>
-   <AppContextSwitchOverrides   
-          value="Switch.System.Net.DontCheckCertificateEKUs=true" /> 
+   <AppContextSwitchOverrides
+          value="Switch.System.Net.DontCheckCertificateEKUs=true" />
 </runtime>
 ```
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > This setting is provided for backward compatibility only. Its use is otherwise not recommended.
 
- 
+
 ### Affected APIs
 * `T:System.Net.Security.SslStream`
 * `T:System.Net.ServicePointManager`
@@ -42,7 +42,7 @@ If this change is undesirable, you can disable certificate EKU OID validation by
 Networking
 
 <!--
-    ### Original Bug #364538 
+    ### Original Bug #364538
 -->
 
 

--- a/Documentation/compatibility/servicepointmanager.securityprotocol-defaults-to-securityprotocoltype.systemdefault.md
+++ b/Documentation/compatibility/servicepointmanager.securityprotocol-defaults-to-securityprotocoltype.systemdefault.md
@@ -12,13 +12,13 @@ NotPlanned
 ### Change Description
 Starting with apps that target the .NET Framework 4.7, the default value of the <xref:System.Net.ServicePointManager.SecurityProtocol?displayProperty=nameWithType> property is <xref:System.Net.SecurityProtocolType.SystemDefault?displayProperty=nameWithType>. This change allows .NET Framework networking APIs based on SslStream (such as FTP, HTTPS, and SMTP) to inherit the default security protocols from the operating system instead of using hard-coded values defined by the .NET Framework. The default varies by operating system and any custom configuration performed by the system administrator. For information on the default SChannel protocol in each version of the Windows operating system, see [Protocols in TLS/SSL (Schannel SSP)](https://msdn.microsoft.com/library/windows/desktop/mt808159.aspx).
 
-For applications that target an earlier version of the .NET Framework, the default value of the <xref:System.Net.ServicePointManager.SecurityProtocol?displayProperty=nameWithType> property depends on the version of the .NET Framework targeted. See the [Networking section of Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.6](~/docs/framework/migration-guide/retargeting/4.5.2-4.6.md#Networking.md) for more information.
+For applications that target an earlier version of the .NET Framework, the default value of the <xref:System.Net.ServicePointManager.SecurityProtocol?displayProperty=nameWithType> property depends on the version of the .NET Framework targeted. See the [Networking section of Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.6](~/docs/framework/migration-guide/retargeting/4.5.2-4.6.md#Networking) for more information.
 
-- [X] Quirked 
+- [X] Quirked
 - [ ] Build-time break
 
 ### Recommended Action
-This change affects applications that target the .NET Framework 4.7 or later versions. 
+This change affects applications that target the .NET Framework 4.7 or later versions.
 
 If you prefer to use a defined protocol rather than relying on the system default, you can explicitly set the value of the <xref:System.Net.ServicePointManager.SecurityProtocol?displayProperty=nameWithType> property.
 

--- a/Documentation/compatibility/x509certificateclaimset_findclaims-considers-all-claimtypes.md
+++ b/Documentation/compatibility/x509certificateclaimset_findclaims-considers-all-claimtypes.md
@@ -27,7 +27,7 @@ method attempts to match the claimType argument only with the last DNS entry.
 
 This change only affects applications targeting the .NET Framework 4.6.1. This
 change may be disabled (or enabled if targetting pre-4.6.1) with the
-[DisableMultipleDNSEntries](~/docs/framework/migration-guide/mitigation-x509certificateclaimset-findclaims-method#mitigation.md)
+[DisableMultipleDNSEntries](~/docs/framework/migration-guide/mitigation-x509certificateclaimset-findclaims-method#mitigation)
 compatibility switch.
 
 ### Affected APIs


### PR DESCRIPTION
@rpetrusha This fixes most of the broken links in dotnet/docs#4288, provided I used the correct bookmark syntax.

One link I haven't tried to fix here is `~/docs/framework/configure-apps/file-schema/appsettings.md` in `x509certificateclaimset_findclaims-considers-all-claimtypes.md`. The target does not exist. Should it be `~/docs/framework/configure-apps/file-schema/appsettings/index.md`?
