### PR TITLE
Corrected language tags, formatting issue

### DIFF
--- a/Documentation/compatibility/binaryformatter-can-fail-to-find-type-from-loadfrom-context.md
+++ b/Documentation/compatibility/binaryformatter-can-fail-to-find-type-from-loadfrom-context.md
@@ -29,12 +29,12 @@ when a type is being loaded from an assembly loaded in a different context, a
 ### Recommended Action
 If this exception is seen, the `Binder` property of the <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter?displayProperty=name> can be set to a custom binder that will find the correct type.
 
-```C#
+```csharp
 var formatter = new BinaryFormatter { Binder = new TypeFinderBinder() }
 ```
 
 And then the custom binder:
-```C#
+```csharp
 public class TypeFinderBinder : SerializationBinder
 {
 	private static readonly string s_assemblyName = Assembly.GetExecutingAssembly().FullName;

--- a/Documentation/compatibility/change-in-path-separator-character-in-zip-files.md
+++ b/Documentation/compatibility/change-in-path-separator-character-in-zip-files.md
@@ -20,7 +20,7 @@ Decompressing a zip file created by an app that targets a previous version of th
 
 ### Recommended Action
 
-The impact of this change on .ZIP files that are decompressed on the Windows operating system by APIs in the .NET Framework <xref:System.IO?displayProperty=nameWithType> namespace should be minimal, since these APIs can seamlessly handle either a slash ("/") or a backslash ("\\") as the path separator character.  
+The impact of this change on .ZIP files that are decompressed on the Windows operating system by APIs in the .NET Framework <xref:System.IO?displayProperty=nameWithType> namespace should be minimal, since these APIs can seamlessly handle either a slash ("`/`") or a backslash ("`\`") as the path separator character.  
 
 If this change is undesirable, you can opt out of it by adding a configuration setting to the [`<runtime>`](https://docs.microsoft.com/dotnet/framework/configure-apps/file-schema/runtime/runtime-element.md) section of your application configuration file. The following example shows both the `<runtime` section and the `Switch.System.IO.Compression.ZipFile.UseBackslash` opt-out switch:
 

--- a/Documentation/compatibility/cspparameters_parentwindowhandle-now-expects-hwnd-value.md
+++ b/Documentation/compatibility/cspparameters_parentwindowhandle-now-expects-hwnd-value.md
@@ -20,7 +20,7 @@ Starting with apps that target the .NET Framework 4.7, a Windows Forms
 application can set the <xref:System.Security.Cryptography.CspParameters.ParentWindowHandle>
 property with code like the following:
 
-```C#
+```csharp
 cspParameters.ParentWindowHandle = form.Handle;
 ```
 
@@ -37,7 +37,7 @@ effect, but on Windows 8 and later versions, it results in a
 ### Recommended Action
 Applications targeting .NET 4.7 or higher wishing to register a parent window relationship are encouraged to use the simplified form:
 
-```C#
+```csharp
 cspParameters.ParentWindowHandle = form.Handle;
 ```
 

--- a/Documentation/compatibility/currentculture-flows-across-tasks.md
+++ b/Documentation/compatibility/currentculture-flows-across-tasks.md
@@ -39,7 +39,7 @@ as the first operation in an async Task. Alternatively, the old behavior (of not
 flowing <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=name>/<xref:System.Globalization.CultureInfo.CurrentUICulture?displayProperty=name>)
 may be opted into by setting the following compatibility switch:
 
-```C#
+```csharp
 AppContext.SetSwitch("Switch.System.Globalization.NoAsyncCurrentCulture", true);
 ```
 

--- a/Documentation/compatibility/currentculture-not-preserved-across-wpf-dispatcher-operations.md
+++ b/Documentation/compatibility/currentculture-not-preserved-across-wpf-dispatcher-operations.md
@@ -62,7 +62,7 @@ can be avoided by targeting the .NET Framework 4.5.2.
 Apps that target .NET Framework 4.6 or later can also work around this by
 setting the following compatibility switch:
 
-    ```
+    ```csharp
     AppContext.SetSwitch("Switch.System.Globalization.NoAsyncCurrentCulture", true);
     ```
 

--- a/Documentation/compatibility/sslstream-support-for-tls-alerts.md
+++ b/Documentation/compatibility/sslstream-support-for-tls-alerts.md
@@ -47,13 +47,13 @@ for .NET 4.6 and above applications running on .NET 4.7 or higher framework.
 
 	Must be the very first thing the application does since ServicePointManager will initialize only once:
 	 
-```C#
+```csharp
     AppContext.SetSwitch("TestSwitch.LocalAppContext.DisableCaching", true);
     AppContext.SetSwitch("Switch.System.Net.DontEnableTlsAlerts", true); // Set to 'false' to enable the feature in .NET 4.6 - 4.6.2.
 ```
 * AppConfig:
 
-```XML
+```xml
 		<runtime>
 			<AppContextSwitchOverrides value="Switch.System.Net.DontEnableTlsAlerts=true"/>
 			<!-- Set to 'false' to enable the feature in .NET 4.6 - 4.6.2. -->

--- a/Documentation/compatibility/wpf-accessibility-improvements.MD
+++ b/Documentation/compatibility/wpf-accessibility-improvements.MD
@@ -48,7 +48,7 @@ __How to opt in or out of these changes__
 In order for the application to benefit from these changes, it must run on the .NET Framework 4.7.1 or later. The application can benefit from these changes in either of the following ways:
 - It is recompiled to target the .NET Framework 4.7.1. These accessibility changes are enabled by default on WPF applications that target the .NET Framework 4.7.1 or later.
 - It opts out of the legacy accessibility behaviors by adding the following [AppContext Switch](https://docs.microsoft.com/dotnet/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element) in the `<runtime>` section of the app config file and setting it to false, as the following example shows.
-```
+```xml
     <?xml version="1.0" encoding="utf-8"?>
     <configuration>
       <startup>


### PR DESCRIPTION
This PR does the following:

- Adds language tags to fenced code where they were absent.
- Changes the C# language tag to csharp.
- Fences a backslash character that was improperly rendering on docs.microsoft.com.

@conniey @chlowell 
