### PR TITLE
Add compatibility document for special relative URI notation NRE.

### DIFF
--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -4,22 +4,22 @@
 Edge
 
 ### Version Introduced
-4.7.3
+4.7.2
 
 ### Source Analyzer Status
 NotPlanned
 
 ### Change Description
 
-<xref:System.Uri> will no longer throw a NullReferenceException when calling <xref:System.Uri.TryCreate> on certain relative URIs containing Unicode.
+<xref:System.Uri> will no longer throw a <xref:System.NullReferenceException> when calling <xref:System.Uri.TryCreate%2A> on certain relative URIs containing Unicode.
 
 The simplest reproduction of the <xref:System.NullReferenceException> is below, with the two statements being equivalent:
  ```C#
 bool success = Uri.TryCreate("http:%C3%A8", UriKind.RelativeOrAbsolute, out Uri href);
 bool success = Uri.TryCreate("http:è", UriKind.RelativeOrAbsolute, out Uri href);
  ```
-To reproduce the <xref:System.NullReferenceException> the two following items must be true:
-- The URI must be specified as relative by prepending it with ‘http:’ and not followed by ‘//’.
+To reproduce the <xref:System.NullReferenceException>, the following items must be true:
+- The URI must be specified as relative by prepending it with ‘http:’ and not following it with ‘//’.
 - The URI must contain percent-encoded Unicode or unreserved symbols.
 
 - [ ] Quirked
@@ -29,7 +29,7 @@ To reproduce the <xref:System.NullReferenceException> the two following items mu
 Users depending on this behavior to disallow relative URIs should instead specify <xref:System.UriKind.Absolute> when creating a URI.
 
 ### Affected APIs
-* `T:System.Uri.TryCreate`
+* `Overload:System.Uri.TryCreate`
 
 ### Category
 Core

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -11,7 +11,7 @@ NotPlanned
 
 ### Change Description
 
-<xref:System.Uri> will no longer throw a NullReferenceException when calling <xref:System.Uri.TryCreate> on unusual relative URIs containing Unicode.
+<xref:System.Uri> will no longer throw a NullReferenceException when calling <xref:System.Uri.TryCreate> on certain relative URIs containing Unicode.
 
 The simplest reproduction of the <xref:System.NullReferenceException> is below, with the two statements being equivalent:
  ```C#

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -26,7 +26,7 @@ To reproduce the <xref:System.NullReferenceException>, the following items must 
 - [ ] Build-time break
 
 ### Recommended Action
-Users depending on this behavior to disallow relative URIs should instead specify <xref:System.UriKind.Absolute?displayProperty=fullName> when creating a URI.
+Users depending on this behavior to disallow relative URIs should instead specify <xref:System.UriKind.Absolute?displayProperty=nameWithType> when creating a URI.
 
 ### Affected APIs
 * `Overload:System.Uri.TryCreate`

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -26,7 +26,7 @@ To reproduce the <xref:System.NullReferenceException>, the following items must 
 - [ ] Build-time break
 
 ### Recommended Action
-Users depending on this behavior to disallow relative URIs should instead specify <xref:System.UriKind.Absolute> when creating a URI.
+Users depending on this behavior to disallow relative URIs should instead specify <xref:System.UriKind.Absolute?displayProperty=fullName> when creating a URI.
 
 ### Affected APIs
 * `Overload:System.Uri.TryCreate`

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -14,7 +14,7 @@ NotPlanned
 <xref:System.Uri> will no longer throw a <xref:System.NullReferenceException> when calling <xref:System.Uri.TryCreate%2A> on certain relative URIs containing Unicode.
 
 The simplest reproduction of the <xref:System.NullReferenceException> is below, with the two statements being equivalent:
- ```C#
+ ```csharp
 bool success = Uri.TryCreate("http:%C3%A8", UriKind.RelativeOrAbsolute, out Uri href);
 bool success = Uri.TryCreate("http:è", UriKind.RelativeOrAbsolute, out Uri href);
  ```

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -11,14 +11,14 @@ NotPlanned
 
 ### Change Description
 
-System.Uri will no longer throw a NullReferenceException when calling TryCreate on unusual relative URIs containing Unicode.
+<xref:System.Uri> will no longer throw a NullReferenceException when calling <xref:System.Uri.TryCreate> on unusual relative URIs containing Unicode.
 
-The simplest reproduction of the NullReferenceException is below, with the two statements being equivalent:
+The simplest reproduction of the <xref:System.NullReferenceException> is below, with the two statements being equivalent:
  ```C#
 bool success = Uri.TryCreate("http:%C3%A8", UriKind.RelativeOrAbsolute, out Uri href);
 bool success = Uri.TryCreate("http:è", UriKind.RelativeOrAbsolute, out Uri href);
  ```
-To reproduce the NullReferenceException the two following items must be true:
+To reproduce the <xref:System.NullReferenceException> the two following items must be true:
 - The URI must be specified as relative by prepending it with ‘http:’ and not followed by ‘//’.
 - The URI must contain percent-encoded Unicode or unreserved symbols.
 
@@ -26,7 +26,7 @@ To reproduce the NullReferenceException the two following items must be true:
 - [ ] Build-time break
 
 ### Recommended Action
-Users depending on this behavior to disallow relative URIs should instead specify `T:System.UriKind.Absolute` when creating a URI.
+Users depending on this behavior to disallow relative URIs should instead specify <xref:System.UriKind.Absolute> when creating a URI.
 
 ### Affected APIs
 * `T:System.Uri.TryCreate`

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -13,7 +13,7 @@ NotPlanned
 
 System.Uri will no longer throw a NullReferenceException when calling TryCreate on unusual relative URIs containing Unicode.
 
-The simplest reproduction of the NRE is below, with the two statements being equivalent:
+The simplest reproduction of the NullReferenceException is below, with the two statements being equivalent:
  ```C#
 bool success = Uri.TryCreate("http:%C3%A8", UriKind.RelativeOrAbsolute, out Uri href);
 bool success = Uri.TryCreate("http:è", UriKind.RelativeOrAbsolute, out Uri href);

--- a/Documentation/compatibility/uri-unicode-scheme-only-relative.md
+++ b/Documentation/compatibility/uri-unicode-scheme-only-relative.md
@@ -1,0 +1,40 @@
+## Support special relative URI notation when Unicode is present
+
+### Scope
+Edge
+
+### Version Introduced
+4.7.3
+
+### Source Analyzer Status
+NotPlanned
+
+### Change Description
+
+System.Uri will no longer throw a NullReferenceException when calling TryCreate on unusual relative URIs containing Unicode.
+
+The simplest reproduction of the NRE is below, with the two statements being equivalent:
+ ```C#
+bool success = Uri.TryCreate("http:%C3%A8", UriKind.RelativeOrAbsolute, out Uri href);
+bool success = Uri.TryCreate("http:è", UriKind.RelativeOrAbsolute, out Uri href);
+ ```
+To reproduce the NullReferenceException the two following items must be true:
+- The URI must be specified as relative by prepending it with ‘http:’ and not followed by ‘//’.
+- The URI must contain percent-encoded Unicode or unreserved symbols.
+
+- [ ] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Users depending on this behavior to disallow relative URIs should instead specify `T:System.UriKind.Absolute` when creating a URI.
+
+### Affected APIs
+* `T:System.Uri.TryCreate`
+
+### Category
+Core
+
+<!--
+    ### Original Bug
+    https://devdiv.visualstudio.com/DevDiv/_workitems/edit/287019
+-->


### PR DESCRIPTION
This additional page documents a change to `System.Uri` that fixes special relative URI notation when Unicode is present. This change is very unlikely to break things for users, but we're taking a cautious approach when documenting URI changes.

cc: @karelz @davidsh @rpetrusha 