### PR TITLE
Add compatibility document for System.Uri consistent reserved character set

### DIFF
--- a/Documentation/compatibility/uri-reserved-characters-consistent.md
+++ b/Documentation/compatibility/uri-reserved-characters-consistent.md
@@ -10,11 +10,11 @@ Minor
 NotPlanned
 
 ### Change Description
-In <xref:System.Uri?displayProperty=fullName>, certain percent encoded characters that were sometimes decoded are now consistently left encoded. This occurs across the properties and methods that access the path, query, fragment, or userinfo components of the URI. 
+In <xref:System.Uri?displayProperty=fullName>, certain percent-encoded characters that were sometimes decoded are now consistently left encoded. This occurs across the properties and methods that access the path, query, fragment, or userinfo components of the URI. 
 The behavior will change only when both of the following are true:
-  - The URI contains the encoded form of any of the following reserved characters: " : ", " ' ", " ( ",  " ) ", " ! " or " * ".
+  - The URI contains the encoded form of any of the following reserved characters: `:`, `'`, `(`, `)`, `!` or `*`.
   - The URI contains a Unicode or encoded non-reserved character.
-If both of the above are true, the encoded reserved characters will be left encoded. In previous versions of the .NET Framework, they will be decoded.
+If both of the above are true, the encoded reserved characters are left encoded. In previous versions of the .NET Framework, they are decoded.
 
 - [x] Quirked
 - [ ] Build-time break

--- a/Documentation/compatibility/uri-reserved-characters-consistent.md
+++ b/Documentation/compatibility/uri-reserved-characters-consistent.md
@@ -10,7 +10,7 @@ Minor
 NotPlanned
 
 ### Change Description
-In System.Uri, certain percent encoded characters that were sometimes decoded are now consistently left encoded. This occurs across the properties and methods that access the path, query, fragment, or userinfo components of the URI. 
+In <xref:System.Uri?displayProperty=fullName>, certain percent encoded characters that were sometimes decoded are now consistently left encoded. This occurs across the properties and methods that access the path, query, fragment, or userinfo components of the URI. 
 The behavior will change only when both of the following are true:
   - The URI contains the encoded form of any of the following reserved characters: " : ", " ' ", " ( ",  " ) ", " ! " or " * ".
   - The URI contains a Unicode or encoded non-reserved character.

--- a/Documentation/compatibility/uri-reserved-characters-consistent.md
+++ b/Documentation/compatibility/uri-reserved-characters-consistent.md
@@ -1,7 +1,7 @@
 ## Ensure System.Uri uses a consistent reserved character set
 
 ### Scope
-Major
+Minor
 
 ### Version Introduced
 4.7.2

--- a/Documentation/compatibility/uri-reserved-characters-consistent.md
+++ b/Documentation/compatibility/uri-reserved-characters-consistent.md
@@ -1,0 +1,45 @@
+## Ensure System.Uri uses a consistent reserved character set
+
+### Scope
+Major
+
+### Version Introduced
+4.7.2
+
+### Source Analyzer Status
+NotPlanned
+
+### Change Description
+In System.Uri, certain percent encoded characters that were sometimes decoded are now consistently left encoded. This occurs across the properties and methods that access the path, query, fragment, or userinfo components of the URI. 
+The behavior will change only when both of the following are true:
+  - The URI contains the encoded form of any of the following reserved characters: " : ", " ' ", " ( ",  " ) ", " ! " or " * ".
+  - The URI contains a Unicode or encoded non-reserved character.
+If both of the above are true, the encoded reserved characters will be left encoded. In previous versions of the .NET Framework, they will be decoded.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+For applications that target versions of .NET Framework starting with 4.7.2, the new decoding behavior is enabled by default. If this change is undesirable, you can disable it by adding the following [AppContextSwitchOverrides](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) switch to the `<runtime>` section of the application configuration file:
+```xml
+<runtime>
+<AppContextSwitchOverrides value="Switch.System.Uri.DontEnableStrictRFC3986ReservedCharacterSets=true" />
+</runtime>
+```
+For applications that target earlier versions of the .NET Framework but are running under versions starting with .NET Framework 4.7.2, the new decoding behavior is disabled by default. You can enable it by adding the following [AppContextSwitchOverrides](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) switch to the `<runtime>` section of the application configuration file::
+```xml
+<runtime>
+<AppContextSwitchOverrides value="Switch.System.Uri.DontEnableStrictRFC3986ReservedCharacterSets=false" />
+</runtime>
+```
+
+### Affected APIs
+* `T:System.Uri`
+
+### Category
+Core
+
+<!--
+    ### Original Bug
+    https://devdiv.visualstudio.com/DevDiv/_workitems/edit/150266
+-->


### PR DESCRIPTION
This additional page documents a change to `System.Uri` that ensures the reserved character set is consistent when Unicode and encoded non-reserved characters are present. Out of the changes I'm documenting for 4.7.2 this is the most significant.

cc: @karelz @davidsh @rpetrusha