### PR TITLE
Compatibility doc: Allow Unicode in URIs that resemble UNC shares

### DIFF
--- a/Documentation/compatibility/uri-unc-shares-normalized.md
+++ b/Documentation/compatibility/uri-unc-shares-normalized.md
@@ -11,7 +11,7 @@ NotPlanned
 
 ### Change Description
 In <xref:System.Uri?displayProperty=fullName>, constructing a file URI containing both a UNC share name and Unicode characters will no longer result in a URI with invalid internal state. The behavior will change only when all of the following are true:
-  - The URI has the scheme `file`, and is followed by four or more slashes.
+  - The URI has the scheme `file:`, and is followed by four or more slashes.
   - The host name begins with an underscore or other non-reserved symbol.
   - The URI contains Unicode characters.
 

--- a/Documentation/compatibility/uri-unc-shares-normalized.md
+++ b/Documentation/compatibility/uri-unc-shares-normalized.md
@@ -11,7 +11,7 @@ NotPlanned
 
 ### Change Description
 In <xref:System.Uri?displayProperty=fullName>, constructing a file URI containing both a UNC share name and Unicode characters will no longer result in a URI with invalid internal state. The behavior will change only when all of the following are true:
-  - The URI has the scheme `file:`, and is followed by four or more slashes.
+  - The URI has the scheme `file:` and is followed by four or more slashes.
   - The host name begins with an underscore or other non-reserved symbol.
   - The URI contains Unicode characters.
 

--- a/Documentation/compatibility/uri-unc-shares-normalized.md
+++ b/Documentation/compatibility/uri-unc-shares-normalized.md
@@ -1,0 +1,33 @@
+## Allow Unicode in URIs that resemble UNC shares
+
+### Scope
+Edge
+
+### Version Introduced
+4.7.2
+
+### Source Analyzer Status
+NotPlanned
+
+### Change Description
+In <xref:System.Uri?displayProperty=fullName>, constructing a file URI containing both a UNC share name and Unicode characters will no longer result in a URI with invalid internal state. The behavior will change only when all of the following are true:
+  - The URI has the scheme file, and is followed by four or more slashes.
+  - The host name begins with an underscore or other non-reserved symbol.
+  - The URI contains Unicode characters.
+
+- [ ] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Applications working with URIs consistently containing Unicode could have conceivably used this behavior to disallow references to UNC shares. Those applications should use <xref:System.Uri.IsUnc> instead.
+
+### Affected APIs
+* `T:System.Uri`
+
+### Category
+Core
+
+<!--
+    ### Original Bug
+    https://devdiv.visualstudio.com/DevDiv/_workitems/edit/95292
+-->

--- a/Documentation/compatibility/uri-unc-shares-normalized.md
+++ b/Documentation/compatibility/uri-unc-shares-normalized.md
@@ -11,7 +11,7 @@ NotPlanned
 
 ### Change Description
 In <xref:System.Uri?displayProperty=fullName>, constructing a file URI containing both a UNC share name and Unicode characters will no longer result in a URI with invalid internal state. The behavior will change only when all of the following are true:
-  - The URI has the scheme file, and is followed by four or more slashes.
+  - The URI has the scheme `file`, and is followed by four or more slashes.
   - The host name begins with an underscore or other non-reserved symbol.
   - The URI contains Unicode characters.
 


### PR DESCRIPTION
This additional page documents a change to `System.Uri` that fixes parsing for UNC shares when Unicode is present. This is the last of our 4.7.2 breaking changes to URI, and I think it is the least likely to be a real problem. Again though, we're taking a cautious approach with URI :)

cc: @karelz @davidsh @rpetrusha