### PR TITLE
Known issues documentation for DevDiv VSO 560016

### DIFF
--- a/releases/net472/KnownIssues/560016-XBAP Applications targeting .NET 2.0,3.5 select wrong runtime version.md
+++ b/releases/net472/KnownIssues/560016-XBAP Applications targeting .NET 2.0,3.5 select wrong runtime version.md
@@ -2,7 +2,7 @@
 
 ## Symptoms
 
-When a XAML Browser Application (XBAP) that targets .NET Framework 3.5 is launched, it is loaded in CLR v4 incorrectly instead of being launched under CLR v2.0 as is expected. Along with the incorrect CLR, the .NET Framework libraries are also loaded from the latest version of .NET (.NET 4.x), and not .NET 3.5. Many XBAP applications launch and work normally under CLR v4, but some XBAP's would fail. The failure-mode would be specific to the individual application and cannot be easily generalized. 
+When a XAML Browser Application (XBAP) that targets .NET Framework 3.5 is launched, it is loaded in CLR v4 incorrectly instead of being launched under CLR v2.0 as is expected. Along with the incorrect CLR, the .NET Framework libraries are also loaded from the latest version of .NET (.NET 4.x), and not .NET 3.5. Many XBAP applications launch and work normally under CLR v4, but some XBAP's fail. The failure-mode is specific to the individual application and cannot be easily generalized. 
 
 ## Resolution
 

--- a/releases/net472/KnownIssues/560016-XBAP Applications targeting .NET 2.0,3.5 select wrong runtime version.md
+++ b/releases/net472/KnownIssues/560016-XBAP Applications targeting .NET 2.0,3.5 select wrong runtime version.md
@@ -1,28 +1,55 @@
-# [|Known Issue Title|]
-XBAP Applications targeting .NET 2.0/.NET 3.5 select wrong runtime (v4.0 CLR) instead of v2.0 CLR 
+# XBAP applications that target .NET Framework 3.5 select the wrong runtime (v4 CLR) instead of v2.0 CLR 
 
 ## Symptoms
-[|Description of the symtopms|]
-When a XAML Browser Application (XBAP) targeting .NET 2.0/.NET 3.5 is launched, it is loaded in CLR v4 incorrectly instead of being launched under CLR v2 as is expected. Along with the incorrect CLR, the .NET Framework libraries are also loaded from the latest version of .NET (.NET 4.x), and not .NET 3.5. Many XBAP's launch and work normally under CLR v4, but some XBAP's would fail. The failure-mode would be specific to the individual application and cannot be easily generalized. 
 
-## Cause
-[|Description of the root cause(s)|]
+When a XAML Browser Application (XBAP) that targets .NET Framework 3.5 is launched, it is loaded in CLR v4 incorrectly instead of being launched under CLR v2.0 as is expected. Along with the incorrect CLR, the .NET Framework libraries are also loaded from the latest version of .NET (.NET 4.x), and not .NET 3.5. Many XBAP applications launch and work normally under CLR v4, but some XBAP's would fail. The failure-mode would be specific to the individual application and cannot be easily generalized. 
 
 ## Resolution
-[|Description of the resolution|]
-A fix will be released shortly for .NET 4.7.2 on Windows 10 Version 1804. .NET 4.7.2 on all other OS platforms already has this fix. 
 
-The fix for this issue must be enabled by customers who have problems running XBAP Applications targeting .NET 2.0/3.5 under CLR v4. The fix can be enabled by setting the following registry keys: 
+A fix will be released shortly for .NET Framework 4.7.2 on Windows 10 Version 1804. .NET Framework 4.7.2 on all other OS platforms already has this fix. 
 
+The fix for this issue must be enabled by customers who have problems running XBAP applications that target .NET Framework 3.5 under CLR v4. The fix can be enabled by setting the following registry keys: 
 
-	Keys: 
-		HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting (32-bit on 64-bit OS)
-		HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting
-	Value Name:	DoNotLaunchVersion3HostedApplicationInVersion4Runtime
-		Value Kind: REG_DWORD 
-		Values: 
-			0, or value is absent (Default)	:	XBAP's targeting v2.0/3.5 and v4.x .NET Framework will be launched under CLR v4	
-			1 (or any non-zero value)		:	XBAP's targeting v2.0/3.5 .NET Framework will be launched under CLR v2, and XBAP's targeting .NET Framework 4.x will be launched under CLR v4 
+    <table>
+        <tr>
+            <th>Platform Architecture</th>
+            <th>Registry Key</th>
+            <th>Value Name</th>
+            <th>Value Kind</th>
+            <th>Value</th>
+            <th>Description</th>
+        </tr>
+        <tr>
+            <td rowspan="2">32-bit</td>
+            <td rowspan="2"><code>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting</code></td>
+            <td rowspan="2"><code>DoNotLaunchVersion3HostedApplicationInVersion4Runtime</code></td>
+            <td rowspan="2"><code>REG_DWORD</code></td>
+            <td><code>0</code>, or value does not exist</td>
+            <td>XBAP applications that target .NET Framework 3.5 or.NET Framework 4.x will be both launched under CLR v4</td>
+        </tr>
+        <tr>
+            <td><code>1</code>, or any non-zero value</td>
+            <td>XBAP applications that target .NET Framework 3.5 will be launched under CLR v2, and XBAP applications that target .NET Framework 4.x will be launched under CLR v4</td>
+        </tr>
+        <tr>
+            <td rowspan="2">64-bit</td>
+            <td rowspan="2">
+                Both of these keys should be set: <p>
+                <ul>
+                    <li><code>HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting</code></li>
+                    <li><code>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting</code></li>
+                </ul>
+            </td>
+            <td rowspan="2"><code>DoNotLaunchVersion3HostedApplicationInVersion4Runtime</code></td>
+            <td rowspan="2"><code>REG_DWORD</code></td>
+            <td><code>0</code>, or value does not exist</td>
+            <td>XBAP applications that target .NET Framework 3.5 or.NET Framework 4.x will be both launched under CLR v4</td>
+        </tr>
+        <tr>
+            <td><code>1</code>, or any non-zero value</td>
+            <td>XBAP applications that target .NET Framework 3.5 will be launched under CLR v2, and XBAP applications that target .NET Framework 4.x will be launched under CLR v4</td>
+        </tr>
+    </table>
 
 ## More information
-.NET 4.6.2, .NET 4.7, .NET 4.7.1 are also affected by this issue. A fix for these versions of .NET Framework will be released shortly. 
+.NET Framework 4.6.2, .NET Framework 4.7, and .NET Framework 4.7.1 are also affected by this issue. A fix for these versions of .NET Frameworks will be released shortly. 

--- a/releases/net472/KnownIssues/560016-XBAP Applications targeting .NET 2.0,3.5 select wrong runtime version.md
+++ b/releases/net472/KnownIssues/560016-XBAP Applications targeting .NET 2.0,3.5 select wrong runtime version.md
@@ -1,0 +1,28 @@
+# [|Known Issue Title|]
+XBAP Applications targeting .NET 2.0/.NET 3.5 select wrong runtime (v4.0 CLR) instead of v2.0 CLR 
+
+## Symptoms
+[|Description of the symtopms|]
+When a XAML Browser Application (XBAP) targeting .NET 2.0/.NET 3.5 is launched, it is loaded in CLR v4 incorrectly instead of being launched under CLR v2 as is expected. Along with the incorrect CLR, the .NET Framework libraries are also loaded from the latest version of .NET (.NET 4.x), and not .NET 3.5. Many XBAP's launch and work normally under CLR v4, but some XBAP's would fail. The failure-mode would be specific to the individual application and cannot be easily generalized. 
+
+## Cause
+[|Description of the root cause(s)|]
+
+## Resolution
+[|Description of the resolution|]
+A fix will be released shortly for .NET 4.7.2 on Windows 10 Version 1804. .NET 4.7.2 on all other OS platforms already has this fix. 
+
+The fix for this issue must be enabled by customers who have problems running XBAP Applications targeting .NET 2.0/3.5 under CLR v4. The fix can be enabled by setting the following registry keys: 
+
+
+	Keys: 
+		HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting (32-bit on 64-bit OS)
+		HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\Windows Presentation Foundation\Hosting
+	Value Name:	DoNotLaunchVersion3HostedApplicationInVersion4Runtime
+		Value Kind: REG_DWORD 
+		Values: 
+			0, or value is absent (Default)	:	XBAP's targeting v2.0/3.5 and v4.x .NET Framework will be launched under CLR v4	
+			1 (or any non-zero value)		:	XBAP's targeting v2.0/3.5 .NET Framework will be launched under CLR v2, and XBAP's targeting .NET Framework 4.x will be launched under CLR v4 
+
+## More information
+.NET 4.6.2, .NET 4.7, .NET 4.7.1 are also affected by this issue. A fix for these versions of .NET Framework will be released shortly. 


### PR DESCRIPTION
Known issues documentation for DevDiv VSO 560016: Bug 560016: [Net472Rel1Last_C Port]: DTS: RS1 LTSB + .NET 4.7: XBAP applications targeting .NET 2.0/3.5 select wrong runtime version