### PR TITLE
Fixed qualified xref

### DIFF
--- a/Documentation/compatibility/WCFSDKToolsAccessibilityChangesIn4.7.1.md
+++ b/Documentation/compatibility/WCFSDKToolsAccessibilityChangesIn4.7.1.md
@@ -11,7 +11,7 @@ NotPlanned
 
 ### Change Description
 
-In the .NET Framework SDK 4.7.1, the svcconfigedit.exe and svctraceviewer.exe tools have been improved by fixing varied accessibility issues. Most of these were small issues like a name not being defined or certain UI automation patterns not being implemented correctly. While many users wouldn’t be aware of these incorrect values, customers who use assistive technologies like screen readers will find these SDK tools more accessible. Certainly, these fixes change some previous behaviors, like keyboard focus order.
+In the .NET Framework SDK 4.7.1, the SvcConfigEditor.exe and SvcTraceViewer.exe tools have been improved by fixing varied accessibility issues. Most of these were small issues like a name not being defined or certain UI automation patterns not being implemented correctly. While many users wouldn’t be aware of these incorrect values, customers who use assistive technologies like screen readers will find these SDK tools more accessible. Certainly, these fixes change some previous behaviors, like keyboard focus order.
 
 In order to get all the accessibility fixes in these tools, you can the following to your app.config file:
 ```xml

--- a/Documentation/compatibility/winforms-accessibility-changes-472.md
+++ b/Documentation/compatibility/winforms-accessibility-changes-472.md
@@ -45,7 +45,7 @@ __Use of OS-defined colors in High Contrast themes__
 - <xref:System.Windows.Forms.Button>, <xref:System.Windows.Forms.RadioButton> and <xref:System.Windows.Forms.CheckBox> controls with <xref:System.Windows.Forms.Control.FlatStyle> set to <xref:System.Windows.Forms.FlatStyle.Flat?displayProperty=nameWithType> or <xref:System.Windows.Forms.FlatStyle.Popup?displayProperty=nameWithType> now use OS-defined colors in High Contrast theme when selected. Previously, text and background colors were not contrasting and were hard to read.
 - Controls contained within a <xref:System.Windows.Forms.GroupBox> that has its <xref:System.Windows.Forms.Control.Enabled> property set to `false` will now use OS-defined colors in High Contrast theme.
 - The<xref:System.Windows.Forms.ToolStripButton>, <xref:System.Windows.Forms.ToolStripComboBox>, and <xref:System.Windows.Forms.ToolStripDropDownButton> controls have an increased luminosity contrast ratio in High Contrast Mode. 
-- <xref:System.Windows.Forms.DataGridViewLinkButton> will by default use OS-defined colors in High Contrast mode for the <xref:System.Windows.Forms.DataGridViewLinkButton.LinkColordisplayProperty=nameWithType> property.
+- <xref:System.Windows.Forms.DataGridViewLinkButton> will by default use OS-defined colors in High Contrast mode for the <xref:System.Windows.Forms.DataGridViewLinkButton.LinkColor?displayProperty=nameWithType> property.
 
 NOTE: Windows 10 has changed values for some high contrast system colors. Windows Forms Framework is based on the Win32 framework. For the best experience, run on the latest version of Windows and opt in to the latest OS changes by adding an app.manifest file in a test application and uncommenting the following code:
 ```
@@ -56,7 +56,7 @@ NOTE: Windows 10 has changed values for some high contrast system colors. Window
 __Improved Narrator support__
 - Narrator now announces the value of the <xref:System.Windows.Forms.Keys.ShortcutKeys?displayProperty=nameWithType> property when announcing the text of a <xref:System.Windows.Forms.ToolStripMenuItem>. 
 - Narrator now indicates when a <xref:System.Windows.Forms.ToolStripMenuItem> has its <xref:System.Windows.Forms.Control.Enabled> property set to `false`.
-- Narrator now gives feedback on the state of a check box when the <xref:System.Windows.Forms.ListView.CheckBoxes?displayProperty=fullName> property is set to `true`.
+- Narrator now gives feedback on the state of a check box when the <xref:System.Windows.Forms.ListView.CheckBoxes?displayProperty=nameWithType> property is set to `true`.
 - Narrator Scan Mode focus order is now consistent with the visual order of the controls on the ClickOnce download dialog window.
 
 __Improved DataGridView Accessibility support__

--- a/Documentation/compatibility/winforms-accessibility-changes-472.md
+++ b/Documentation/compatibility/winforms-accessibility-changes-472.md
@@ -65,7 +65,7 @@ __Improved DataGridView Accessibility support__
 - The <xref::System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Parent?displayProperty=nameWithType> property now returns the correct parent control.
 
 __Improved Visual cues__
-- The <xref:System.Windows.Forms.RadioButton> and <xref:System.Windows.Forms.CheckBox> controls with an empty <xref:System.Windows.Forms.ButtonBase.Text> property will now display a focus indicator when they recieve focus.
+- The <xref:System.Windows.Forms.RadioButton> and <xref:System.Windows.Forms.CheckBox> controls with an empty <xref:System.Windows.Forms.ButtonBase.Text> property will now display a focus indicator when they receive focus.
 
 __Improved Property Grid Support__
 - The <xref:System.Windows.Forms.PropertyGrid> control child elements now return a `true` for the  <xref:System.Windows.Automation.ValuePattern.IsReadOnlyProperty> property only when a PropertyGrid element is enabled.


### PR DESCRIPTION
A `?` was missing between the property name and `displayProperty=nameWithType`.
