### PR TITLE
Revised readme generator code to handle categories file

### DIFF
--- a/src/bc-readme-gen/Program.cs
+++ b/src/bc-readme-gen/Program.cs
@@ -27,7 +27,7 @@ namespace bc_readme_gen
 
             foreach(var changeFile in bcdir.GetFiles("*.md"))
             {
-                if (changeFile.Name == "! Template.md" || changeFile.Name == "README.md")
+                if (changeFile.Name == "! Template.md" || changeFile.Name == "README.md" || changeFile.Name == "!categories.md")
                 {
                     continue;
                 }


### PR DESCRIPTION
Modified the app compat readme generator, bc-readme-gen, to handle an additional support file, !categories.md, which lists the app compat categories.


//cc @richlander 
