### PR TITLE
Web Application -> Web Applications

### DIFF
--- a/Documentation/compatibility/aspnet-472-compat-doc.md
+++ b/Documentation/compatibility/aspnet-472-compat-doc.md
@@ -26,4 +26,4 @@ If you find that regular expressions in your web application do not work after u
 ```
 
 ### Category
-Web Application
+Web Applications


### PR DESCRIPTION
The plural category is conventional and used in migration guide generation to map include paths.

This will fix dotnet/docs#5582.

cc @rpetrusha 