### PR TITLE
Fix the .NET native 1.7 release notes

### DIFF
--- a/releases/UWP/net-native1.7/README.md
+++ b/releases/UWP/net-native1.7/README.md
@@ -3,7 +3,7 @@ You can see what was included in each .NET Native 1.7 ([Microsoft.NETCore.Univer
 
 When using Visual Studio these packages require Visual Studio 2017 or later.
 
-### UWP 5.4.2 (.NET native tools 1.7.3) (January 9th, 2018)
+### UWP 6.0.6 (.NET native tools 1.7.3) (January 9th, 2018)
 - Fixed CVE-2018-0786: Security Feature Bypass in X509 Certificate Validation: https://github.com/Microsoft/dotnet/issues/597
 
 ### UWP 6.0.5 (.NET native tools 1.7.3) (December 12th, 2017)
@@ -12,6 +12,9 @@ When using Visual Studio these packages require Visual Studio 2017 or later.
 ### UWP 6.0.4 (.NET native tools 1.7.2) (December 4th, 2017)
 - Fixed an unhandled exception when ClientWebSocket loses connection to server. [518456]
 - Fixed a regression in the 1.7 toolchain causing winmd file corruption when the file stream is left open. [496929]
+
+### UWP 5.4.2 (.NET native tools 1.7.1) (January 9th, 2018)
+- Fixed CVE-2018-0786: Security Feature Bypass in X509 Certificate Validation: https://github.com/Microsoft/dotnet/issues/597
 
 ### UWP 5.4.1 (.NET native tools 1.7.1) (October 9th, 2017)
 - Fixed an issue with Microsoft.NetNative.targets that prevented C++ hybrid apps from compiling; apps would fail to compile due to an attempt to write a file to a folder that does not exist. [511674]


### PR DESCRIPTION
Fix the .NET native 1.7 release notes to correctly state the package contents of UWP 5.4.2 and UWP 6.0.6