### PR TITLE
add year in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Microsoft Corporation
+Copyright (c) 2018 Microsoft
 
 All rights reserved.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Microsoft
+Copyright (c) 2018 Microsoft Corporation
 
 All rights reserved.
 


### PR DESCRIPTION
As mentioned in #857 I have added 2018 as the year. I've also made changes to the organisation name. Made it Microsoft Corporation rather than just Microsoft.