### PR TITLE
Fix typo

### DIFF
--- a/Documentation/KnownIssues/Template/NETFXKnownIssuesTemplate.md
+++ b/Documentation/KnownIssues/Template/NETFXKnownIssuesTemplate.md
@@ -4,7 +4,7 @@
 // Entries with [| ... |] are fields that must be updated.
 
 ## Symptoms
-[|Description of the symtopms|]
+[|Description of the symtoms|]
 // A description of the symptom(s) that exhibit due to the  underlying issue. 
 
 ## Cause


### PR DESCRIPTION
There's a small typo in the NETFXKnownIssuesTemplate (`symtopms` instead of `symtoms`).