### PR TITLE
Fix code typo in aspnet-472-compat-doc

### DIFF
--- a/Documentation/compatibility/aspnet-472-compat-doc.md
+++ b/Documentation/compatibility/aspnet-472-compat-doc.md
@@ -17,11 +17,11 @@ If you find that regular expressions in your web application do not work after u
 
 ```xml
     <configuration>
-      <appsettings>
+      <appSettings>
       ...
         <add key="dataAnnotations:dataTypeAttribute:disableRegEx" value="false"/>
       ...
-      </appsettings>
+      </appSettings>
     </configuration>
 ```
 


### PR DESCRIPTION
Casing of the 'appSettings' element was wrong, I copied and pasted this into my own config without noticing the casing issue and spent a while figuring out why the setting wasn't working.