### PR TITLE
Changed http to https

### DIFF
--- a/Documentation/compatibility/uri-unicode-bidirectional-characters.md
+++ b/Documentation/compatibility/uri-unicode-bidirectional-characters.md
@@ -13,7 +13,7 @@ NotPlanned
 Unicode specifies several special control characters used to specify the orientation of text.
 In previous versions of the .NET Framework, these characters were incorrectly stripped
 from all URIs even if they were present in their percent-encoded form. In order to better 
-follow [RFC 3987](http://tools.ietf.org/html/rfc3987), we now allow these characters in URIs. When found unencoded
+follow [RFC 3987](https://tools.ietf.org/html/rfc3987), we now allow these characters in URIs. When found unencoded
 in a URI, they are percent-encoded. When found percent-encoded they are left as-is.
 
 - [x] Quirked


### PR DESCRIPTION

This reflects a parallel change made in the [dotnet/docs repo](https://github.com/dotnet/docs/pull/10057). 