### PR TITLE
Fixed broken xrefs from migration

### DIFF
--- a/Documentation/compatibility/aspnet-asp.net-validationcontext.membername-is-null-sometimes.md
+++ b/Documentation/compatibility/aspnet-asp.net-validationcontext.membername-is-null-sometimes.md
@@ -21,6 +21,7 @@ The default behavior of the <xref:System.ComponentModel.DataAnnotations.Validati
 ```
 
 ### Affected APIs
+
 * `P:System.ComponentModel.DataAnnotations.ValidationContext.MemberName`
 
 ### Category

--- a/Documentation/compatibility/aspnet-fix-handling-input-and-label-attributes-for-webforms-checkbox-control.md
+++ b/Documentation/compatibility/aspnet-fix-handling-input-and-label-attributes-for-webforms-checkbox-control.md
@@ -21,6 +21,7 @@ For the correct behavior for restoring attributes on postback, set the `targetFr
 Setting it lower, or not at all, preserves the old incorrect behavior.
 
 ### Affected APIs
+
 * `T:System.Web.UI.WebControls.CheckBox`
 
 ### Category

--- a/Documentation/compatibility/aspnet-invalid-results-from-httprequest.getattributefromheader.md
+++ b/Documentation/compatibility/aspnet-invalid-results-from-httprequest.getattributefromheader.md
@@ -25,6 +25,7 @@ This behavior can also be explicitly controlled with an `appSetting`:
 ```
 
 ### Affected APIs
+
 * `P:System.Web.HttpRequest.Form`
 * `P:System.Web.HttpRequest.Files`
 * `P:System.Web.HttpRequest.ContentEncoding`


### PR DESCRIPTION
Corrects the broken xrefs found in build reports from dotnet/docs#13330.

