### PR TITLE
Escape backslash for reading this document on github

### DIFF
--- a/Documentation/compatibility/change-in-path-separator-character-in-zip-files.md
+++ b/Documentation/compatibility/change-in-path-separator-character-in-zip-files.md
@@ -12,7 +12,7 @@ Planned
 ### Change Description
 For apps that target the .NET Framework 4.6.1 and later versions, the path separator character has changed from a backslash ("\\") to a forward slash ("/") in the <xref:System.IO.Compression.ZipArchiveEntry.FullName> property of <xref:System.IO.Compression.ZipArchiveEntry>  objects created by overloads of the <xref:System.IO.Compression.ZipFile.CreateFromDirectory%2A> method. The change brings the .NET implementation into conformity with section 4.4.17.1 of the [.ZIP File Format Specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) and allows .ZIP archives to be decompressed on non-Windows systems.<br />
 
-Decompressing a zip file created by an app that targets a previous version of the .NET Framework on non-Windows operating systems such as the Macintosh fails to preserve the directory structure. For example, on the Macintosh, it creates a set of files whose filename concatenates the directory path, along with any backslash ("\") characters, and the filename. As a result, the directory structure of decompressed files is not preserved.
+Decompressing a zip file created by an app that targets a previous version of the .NET Framework on non-Windows operating systems such as the Macintosh fails to preserve the directory structure. For example, on the Macintosh, it creates a set of files whose filename concatenates the directory path, along with any backslash ("\\") characters, and the filename. As a result, the directory structure of decompressed files is not preserved.
 
 
 - [X] Quirked


### PR DESCRIPTION
There is no problem on [Microsoft document site](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-ziparchiveentry-fullname-path-separator), however a backslash character is not visible on github as below.

![Screenshot 2021-10-06 191258](https://user-images.githubusercontent.com/554281/136184684-4a55257d-e64a-4d4c-b896-03dd706d5fa0.png)

Green underlined text looks good, while red underlined text looks as empty string.

With this patch, both looks good as below.

![Screenshot 2021-10-06 191828](https://user-images.githubusercontent.com/554281/136184822-011b3636-9d04-4d9c-92cb-792ab1197fa2.png)

